### PR TITLE
Remove pandas dataframe shift

### DIFF
--- a/Predicting-Stock-Prices-Final/Predicting Stock Prices.ipynb
+++ b/Predicting-Stock-Prices-Final/Predicting Stock Prices.ipynb
@@ -1,273 +1,315 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 83,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import quandl\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "import datetime\n",
-    "\n",
-    "from sklearn.model_selection import train_test_split\n",
-    "from sklearn import preprocessing\n",
-    "from sklearn.linear_model import LinearRegression"
-   ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.7"
+    },
+    "colab": {
+      "name": "Predicting Stock Prices.ipynb",
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": 70,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Adj. Close</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Date</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>1997-05-16</th>\n",
-       "      <td>1.729167</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1997-05-19</th>\n",
-       "      <td>1.708333</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1997-05-20</th>\n",
-       "      <td>1.635833</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1997-05-21</th>\n",
-       "      <td>1.427500</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1997-05-22</th>\n",
-       "      <td>1.395833</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2018-03-21</th>\n",
-       "      <td>1581.860000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2018-03-22</th>\n",
-       "      <td>1544.100000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2018-03-23</th>\n",
-       "      <td>1495.560000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2018-03-26</th>\n",
-       "      <td>1555.860000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2018-03-27</th>\n",
-       "      <td>1497.050000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>5248 rows × 1 columns</p>\n",
-       "</div>"
+      "cell_type": "code",
+      "metadata": {
+        "scrolled": true,
+        "id": "jgOsLgfsv3FU",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "import quandl\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "import datetime\n",
+        "\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn import preprocessing\n",
+        "from sklearn.linear_model import LinearRegression"
       ],
-      "text/plain": [
-       "             Adj. Close\n",
-       "Date                   \n",
-       "1997-05-16     1.729167\n",
-       "1997-05-19     1.708333\n",
-       "1997-05-20     1.635833\n",
-       "1997-05-21     1.427500\n",
-       "1997-05-22     1.395833\n",
-       "...                 ...\n",
-       "2018-03-21  1581.860000\n",
-       "2018-03-22  1544.100000\n",
-       "2018-03-23  1495.560000\n",
-       "2018-03-26  1555.860000\n",
-       "2018-03-27  1497.050000\n",
-       "\n",
-       "[5248 rows x 1 columns]"
-      ]
-     },
-     "execution_count": 70,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "quandl.ApiConfig.api_key = 'zZzhwTNJ1Z8SxApaAd8K'\n",
-    "\n",
-    "df = quandl.get(\"WIKI/AMZN\")\n",
-    "df = df[['Adj. Close']]\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 87,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAD8CAYAAACb4nSYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8li6FKAAAgAElEQVR4nO3deXgUVdbA4d9JCAQIsu+LIDsKCkQERVFAQGUEURiYUVBQxlHcGbdRUVFx1FHcBgVE0U9BREVUXBBUQEUEUZA9gmDYl7AlZD/fH1XddNZO0ku28z5PHqpu3apzO3ROV9+quldUFWOMMeVDRHE3wBhjTPhY0jfGmHLEkr4xxpQjlvSNMaYcsaRvjDHliCV9Y4wpRyoUdwPyU6dOHW3evHlxN8MYY0qVVatWHVDVurltK9FJv3nz5qxcubK4m2GMMaWKiGzPa5t17xhjTDliSd8YY8oRS/rGGFOO+O3TF5EZwEBgn6qe4VN+C3AzkAF8qqp3u+X3AWPc8ltV9Qu3fADwPBAJTFfVJ4vS4LS0NOLj40lOTi7K7iYX0dHRNGnShKioqOJuijEmxApyIfcN4CXgTU+BiFwEDALOVNUUEannlncAhgOnA42Ar0Skjbvby8DFQDzwk4jMV9X1hW1wfHw81apVo3nz5ohIYXc32agqBw8eJD4+nhYtWhR3c4wxIea3e0dVlwCHshX/E3hSVVPcOvvc8kHAbFVNUdVtQBzQzf2JU9WtqpoKzHbrFlpycjK1a9e2hB8kIkLt2rXtm5MxZcSOIzvy3V7UPv02wPki8qOIfCsiZ7vljYE/ferFu2V5lecgImNFZKWIrNy/f3+uwS3hB5f9Po0pG9buXcupk0/Nt05Rk34FoBbQHfgXMEeClDlUdaqqxqpqbN26uT5bUCLMmzcPEWHjxo151rn22muZO3cuANdffz3r1/vvzXrzzTc544wz6NixI507d+aZZ57JcSxjjMnN1oStfusUNenHAx+oYwWQCdQBdgJNfeo1ccvyKi+1Zs2aRc+ePZk1a1aB6k+fPp0OHTrkW+ezzz5j8uTJfPnll6xdu5bly5dTvXr1YDTXGFMOREX6vxmjqEl/HnARgHuhtiJwAJgPDBeRSiLSAmgNrAB+AlqLSAsRqYhzsXd+EWMXu+PHj7Ns2TJee+01Zs+e7S1XVcaNG0fbtm3p27cv+/bt82678MIL/T5dPGnSJJ555hkaNWoEQKVKlbjhhhty1Fu0aBGdO3emY8eOjB49mpSUFADuvfdeOnToQKdOnRg/fjwA+/fv58orr+Tss8/m7LPP5rvvvgv49RtjSqYKEf7vzSnILZuzgAuBOiISD0wAZgAzROQ3IBUYpc68i+tEZA6wHkgHblbVDPc444AvcG7ZnKGq64ryonzd/vnt/LLnl0APk8VZDc5i8oDJ+db56KOPGDBgAG3atKF27dqsWrWKrl278uGHH7Jp0ybWr1/P3r176dChA6NHjy5w7N9++42uXbvmWyc5OZlrr72WRYsW0aZNG0aOHMmUKVO45ppr+PDDD9m4cSMiwuHDhwG47bbbuOOOO+jZsyc7duygf//+bNiwocBtMsaUHinpKX7r+E36qjoij01X51H/ceDxXMoXAAv8tqgUmDVrFrfddhsAw4cPZ9asWXTt2pUlS5YwYsQIIiMjadSoEb179w567E2bNtGiRQvatHHuhB01ahQvv/wy48aNIzo6mjFjxjBw4EAGDhwIwFdffZXlWsLRo0c5fvw4MTExQW+bMaZ4Jaf7vwuvRA+45o+/M/JQOHToEIsXL2bt2rWICBkZGYgITz/9dMDHPv3001m1alWRPiwqVKjAihUrWLRoEXPnzuWll15i8eLFZGZmsnz5cqKjowNunzGmZEtMS/Rbx4ZhKKS5c+dyzTXXsH37dv744w/+/PNPWrRowdKlS7ngggt49913ycjIYPfu3Xz99deFOvZ9993Hv/71L/bs2QNAamoq06dPz1Knbdu2/PHHH8TFxQHw1ltv0atXL44fP86RI0e49NJLee655/j1118B6NevHy+++KJ3/19+CW53mDGm5DieetxvHUv6hTRr1iyuuOKKLGVXXnmlt7x169Z06NCBkSNH0qNHjyz1PHe1Xn/99ble1L300ksZN24cffv25fTTT6dLly4cPXo0S53o6Ghef/11hg4dSseOHYmIiODGG2/k2LFjDBw4kE6dOtGzZ0+effZZAF544QVWrlxJp06d6NChA6+88kowfx3GmBLklZX+/77Fuf5aMsXGxmr25Lhhwwbat29fTC0quo4dOzJ//vwSO9RBaf29GmNOkkfcx6UeZpWqxuZWx870w+Diiy+mY8eOJTbhG2PKj1J9Ibe0WLhwYXE3wRhjADvTN8aYcqVUJv2SfB2iNLLfpzGln6oSFRHFPefdk2+9Upf0o6OjOXjwoCWqIPGMp2/38RtTuiWlJZGWmUbN6Jr51it1ffpNmjQhPj6evIZdNoXnmTnLGFN6ffPHNwDEH43Pt16pS/pRUVF2F4wxxmQzcJYz9Mo327/Jt16p694xxhiTt1u73Zrvdkv6xhhThsQ2yvWZLC+/SV9EZojIPncY5ezb7hIRFZE67rqIyAsiEicia0Ski0/dUSKyxf0ZVYTXYowxJhe+N7b4m0ilIGf6bwADsheKSFOgH+A7C+8lOBOntAbGAlPcurVwxuE/B2eS9Akikv8lZmOMMQWSknFyHP2oiACTvqouAQ7lsuk54G7A997JQcCb7jSKy4EaItIQ6A8sVNVDqpoALCSXDxJjjDGFdyLthHc5GGf6OYjIIGCnqv6abVNj4E+f9Xi3LK9yY4wxAfKdPMXfmX6hb9kUkSrA/ThdO0EnImNxuoZo1qxZKEIYY0yZciI9tGf6LYEWwK8i8gfQBPhZRBoAO4GmPnWbuGV5leegqlNVNVZVY+vWrVuE5hljTPlSmDP9Qid9VV2rqvVUtbmqNsfpqumiqnuA+cBI9y6e7sARVd2NMyF6PxGp6V7A7eeWGWOMCVCWpB/omb6IzAJ+ANqKSLyIjMmn+gJgKxAHTANuAlDVQ8BE4Cf351G3zBhjTIBS0gt+947fPn1VHeFne3OfZQVuzqPeDGCGv3jGGGMKJ6hn+sYYY0o23/v0IyUy37qW9I0xppTz7d4RkXzrWtI3xphSznOm/8OYH/zWtaRvjDGlnKdPv24V/7e5W9I3xphS7svfvwSgUoVKfuta0jfGmFLu7bVvAxBdwf+0p5b0jTGmjKgaVdVvnVI3XaIxxpisOtXvREp6CpWjKvuta2f6xhhTykVIBK1rty5Y3RC3xRhjTIidSDtBlagqBaprSd8YY0q5pLQkS/rGGFNeJKUlUbmC//58sKRvjDGlXmJaYoHu3AFL+sYYU6plZGaQnJ5MTMWYAtUvyHj6M0Rkn4j85lP2tIhsFJE1IvKhiNTw2XafiMSJyCYR6e9TPsAtixORewv5uowxxuQiKS0JgKoVg3em/wYwIFvZQuAMVe0EbAbuAxCRDsBw4HR3n/+JSKSIRAIvA5cAHYARbl1jjDEB8Cb9YHXvqOoS4FC2si9VNd1dXY4z5y3AIGC2qqao6jacGbS6uT9xqrpVVVOB2W5dY4wxRbQtYRvr9q8DoFqlagXaJxhP5I4G3nWXG+N8CHjEu2UAf2YrPye3g4nIWGAsQLNmzYLQPGOMKZtOe+E073L1StULtE9AF3JF5N9AOvB2IMfxpapTVTVWVWPr1vU/TKgxxhhIzUgtUL0in+mLyLXAQKCPOzcuwE6gqU+1Jm4Z+ZQbY4wJUMXIigWqV6QzfREZANwNXK6qST6b5gPDRaSSiLQAWgMrgJ+A1iLSQkQq4lzsnV+U2MYYY3Lq3LBzger5PdMXkVnAhUAdEYkHJuDcrVMJWOjOx7hcVW9U1XUiMgdYj9Ptc7OqZrjHGQd8AUQCM1R1XWFflDHGmJym/2U6TU5p4r8iBUj6qjoil+LX8qn/OPB4LuULgAUFapUxxpgCu6jFRQWua0/kGmNMKbTr2C7vckGfxgVL+sYYUyo1fraxd7lGdI18amZlSd8YY0qxeX+dV+A7d8CSvjHGlDon75KHQe0KN7iBJX1jjCll9iftL/K+lvSNMaaUOZZyrMj7WtI3xphSRnG6dx7u9XCh97Wkb4wxpYynT79lrZaF3teSvjHGlDKeM31BCr2vJX1jjCnhVJVPN39KpmZ61wHcYXAKxZK+McaUcHPWzWHgrIH876f/AXamb4wxZdrvCb8DEH80Pku5nekbY0wZtGzHMuDkPLi+D2cVlt+kLyIzRGSfiPzmU1ZLRBaKyBb335puuYjICyISJyJrRKSLzz6j3PpbRGRUkVtsjDHlzGdxnwFwSqVTgNB377wBDMhWdi+wSFVbA4vcdYBLcCZOaY0zz+0UcD4kcMbhPwdnkvQJng8KY4wxuftww4fII0K3xt0AqBDhjIa/Yf8GIETdO6q6BDiUrXgQMNNdngkM9il/Ux3LgRoi0hDoDyxU1UOqmgAsJOcHiTHGGB9D5gwBYMXOFQCkZKQwb+M8rnrvKqBoZ/pFnSO3vqrudpf3APXd5cbAnz714t2yvMpzEJGxON8SaNasWRGbZ4wxZc9dX94V8DECvpDrTope9KsKOY83VVVjVTW2bt26wTqsMcaUOYlpiYXep6hJf6/bbYP77z63fCfQ1KdeE7csr3JjjDG5SM9M91tn44GNhT5uUZP+fMBzB84o4COf8pHuXTzdgSNuN9AXQD8RqelewO3nlhljjMmFpx8/PwknEgp9XL99+iIyC7gQqCMi8Th34TwJzBGRMcB2YJhbfQFwKRAHJAHXAajqIRGZCPzk1ntUVbNfHDbGGOM6b8Z5fus8f8nzhT6u36SvqiPy2NQnl7oK3JzHcWYAMwrVOmOMKYd8H74accYIZv02i5FnjuTNX9/0lq/+x2qiK0QX+tj2RK4xxpQwKRkp3uU7e9xJ4v2JzBw8kza123jL29ZuW6RjF/WWTWOMMSHiOzNWbKNY7/KmcZtYvG0xb615q0hn+WBJ3xhjSpyjKUcBePrip3Ns692iN71b9C7ysa17xxhjSpgpK6cA0LFex6Af25K+McaUICt2ruC/P/wXgMan5DpwQUAs6RtjTAmy5/ge73KTU5oE/fiW9I0xpgSpXKGyd7lGdI2gH9+SvjHGlCCei7ijzxodkuNb0jfGmBLkSMoRAB7q9VBIjm9J3xhjSojXV7/OmPljAKgeXT0kMSzpG2NMmCWcSMgxz+2BpAOMnn+yS6daxWohiW1J3xhjwijuUBy1nqpFxKMR3sSfkZlB3aezzh8SGREZkviW9I0xJoze+OUN7/J7698D4KutX3nL7j3vXn75xy8hix9Q0heRO0RknYj8JiKzRCRaRFqIyI8iEici74pIRbduJXc9zt3ePBgvwBhjSpPG1U4+cHU89ThwcsJzgPvPv58zG5wZsvhFTvoi0hi4FYhV1TOASGA48B/gOVVtBSQAY9xdxgAJbvlzbj1jjClXktKSvMtVoqoA0Petvt6yapVC05fvEWj3TgWgsohUAKoAu4HewFx3+0xgsLs8yF3H3d5HRAo/lbsxxpRiniEWACpFVgp7/CInfVXdCTwD7MBJ9keAVcBhVfVM7hgPeL7LNAb+dPdNd+vXLmp8Y4wpjXYf3+1dVpRMzfSuh7Iv3yOQ7p2aOGfvLYBGQFVgQKANEpGxIrJSRFbu378/0MMZY0yJMXf93CzrV865kjV71wAwtsvYkPblewTSvdMX2Kaq+1U1DfgAOA+o4Xb3ADQBdrrLO4GmAO726sDB7AdV1amqGquqsXXr1s2+2RhjSqX0zHTGLRiXo7zzq50B6FS/U1jaEUjS3wF0F5Eqbt98H2A98DVwlVtnFPCRuzzfXcfdvlizP51gjDFlVNTEKPYm7s1zu283TygF0qf/I84F2Z+Bte6xpgL3AHeKSBxOn/1r7i6vAbXd8juBewNotzHGlBqeQdTy4zsvbigFNF2iqk4AJmQr3gp0y6VuMjA0kHjGGFMaVX8y6zg6a25cQ6dXsnbnVIysGJa22BO5xhgTQompid7lyf0noxOUjvU70rZ2W2/5Rc0v4ppO14SlPZb0jTEmRBJTE1kev9y77jtyZr2q9QCIkAgWj1pMzco1w9KmgLp3jDHG5C1mUox3uVWtVlnO5hXnPpZvRn0T1jbZmb4xxoTA2I/HZln/6pqvsoyceX6z8wFoWK1hWNtlSd8YY0Jg2s/TsqyfUumULOuPXvQo629aT6tarcLZLEv6xhgTiIQTCXy34zu/9apWrJplvUJEBdrXbR+qZuXJkr4xxgTgqveuoufrPTmRdiJLefbB1MJ1S6Y/diHXGGOKICMzgwoTT6bQY6nHqBxVGXCervU8bHXw7oNsS9hWLG3MjSV9Y4wpgo5TOmZZT0xNdIadJOuY+bUq16JW5VrhbFq+rHvHGGOKYMOBDVnWE9NOPoR1LOVYuJtTYJb0jTEmCHyfvE1OTwagWsXQzoJVFJb0jTEmCHzP9D0jZr586cvF1Zw8WdI3xpgg6PNmH++EKFNXTQWgJM4IG1DSF5EaIjJXRDaKyAYR6SEitURkoYhscf+t6dYVEXlBROJEZI2IdAnOSzDGmPA6knzEuxx3S5x3+fGljwPw1PdP5ahXUgR6pv888LmqtgPOBDbgjJO/SFVbA4s4OW7+JUBr92csMCXA2MYYUyziDjmJfkj7ITkeuvL1zfZvwtSiggtkjtzqwAW4k6SoaqqqHsaZN3emW20mMNhdHgS8qY7lONMqhnfQCWOMCYIDSQcAuLP7nVkeuso+GWBZu5DbAtgPvC4iq0VkuohUBeqrqme69z1AfXe5MfCnz/7xbpkxxpQq8UfjAWh8SmNqRNfwlq/ctZLnlz/vXfcdM7+kCCTpVwC6AFNUtTOQSLYpEN05cAs1D66IjBWRlSKycv/+/QE0zxhjQsMz/WGN6BpEyMk0uu3wNm7/4nbv+vhzx4e9bf4EkvTjgXh3rlxw5svtAuz1dNu4/+5zt+8Emvrs38Qty0JVp6pqrKrG1q1bN4DmGWNMaHhuyfRN+Nl9MOyDLEMplxSBTIy+B/hTRDzfX/oA64H5wCi3bBTwkbs8Hxjp3sXTHTji0w1kjDGlxoNfPwhApOSd1K9of0W4mlMogY69cwvwtohUxJkQ/TqcD5I5IjIG2A4Mc+suAC4F4oAkt64xxpQ6J9KdETU9Z/KD2g7io00f5bdLiRFQ0lfVX4DYXDb1yaWuAjcHEs8YY4qb73ALnjt35g2fhzxS8h7Eyo09kWuMMYXgO+9tXn36r1z2SriaU2g2tLIxxvhxJPkINf5Tw39FYO7QuVzZ4coQt6jo7EzfGGP8uOHjG3KUPdzr4VzrVo+uHuLWBMaSvjHG+NGmdpscZWO6jMm1br2q9ULdnIBY0jfGGD9qV66doyy6QnSudRtXK9kDDVjSN8YYPzwPY/nKK+mXpKkRc2NJ3xhj/Pjz6J85yipXqJxr3ZI4hr4vS/rGGOPH8z+eHEStySlNSLw/sUQOsVAQdsumMcb4UTO6JgnJCd71KlFVctT57O+f8fuh38PZrCKxpG+MMX74JvyMzIxc6wxoNSBczQmIde8YY0wBjTxzJB+P+Li4mxEQS/rGGJPNtoRtPPzNw2RqJlN+cmZ2vfe8e5k5eCZdG3Ut5tYFxrp3jDEmm3GfjWPBlgXM+m0Wmw9uBuBY6rFiblVw2Jm+McZkExURBeBN+ODMilUWBJz0RSTSnSP3E3e9hYj8KCJxIvKuO9Y+IlLJXY9ztzcPNLYxxoRCzco1c5S9M+SdYmhJ8AXjTP82YIPP+n+A51S1FZAAeAaoGAMkuOXPufWMMSYg6ZnpxB+N57sd3wXtmB3qdADgyvZX8v3o78l8KLPED6RWUAElfRFpAlwGTHfXBeiNM18uwExgsLs8yF3H3d5HSvqja8aYEi9qYhRNn2tKz9d7smjroqAcU1EAZg6eSY+mPUr8U7aFEeiZ/mTgbsAzMEVt4LCqprvr8YBn9KHGwJ8A7vYjbv0sRGSsiKwUkZX79+8PsHnGmLKs31v9sqxPWjYpoOMdST7CzqM7vQ9Z5TfxeWlV5Lt3RGQgsE9VV4nIhcFqkKpOBaYCxMbGarCOa4wpexZuXZhlPSktibhDcTSv0ZwKEYVLbz/t/Ilu07tlKfNMh1iWBPIxdh5wuYj8AczG6dZ5HqghIp7fdhNgp7u8E2gK4G6vDhwMIL4xphzbc3yPd/nzv38OQFRkFK1fbM39i+4v9PGyJ3yg1I6vk58iJ31VvU9Vm6hqc2A4sFhV/w58DVzlVhsFeKaIn++u425f7E6WbowxhbL72G4a/rchAG8PeZt2ddoBsGT7EgB+T8g6Bk5SWlKhx8V5tt+zQWhpyROKh7PuAWaLyGPAauA1t/w14C0RiQMO4XxQGGNMoT367aPe5W6Nu+Xoe88+6UnVJ6oCkP5geq5n70lpSQDcFHsT2w5v45+x/+Qvbf8S7GaXCEFJ+qr6DfCNu7wVyPE9SVWTgaHBiGeMKd+aVm/qXW5VqxWJqYlZti/dsTTX/SYvn8y+xH385+Ksd4zvT3RuGunSsAsvX/ZykFtbspS9S9PGmDLPc2buUbViVVrXau1d33hgI4988wipGanc/vnt3vLxC8fz1PdPeT8k2r/cnldXvkqGOiNnFvbib2lkSd8YU+rMWD0DgNQHUr1lm2/ZjE5Qmp7ifAt4+NuHiXkiJssEKB4xk2JYtHURGw9s5MZPb/ROh1gWL9xmZ0nfGFOqXP3B1ew+vhtw7tbJbvgZJy8XpmWm5Xmcvm/19S57kn5ZvC8/u7L/Co0xpd5tn93GqZNPJSU9hbfXvp1v3as6XJWjrEeTHvnu0/altgAkpycXvZGlhCV9Y0yJlpKewgsrXmDHkR30fL2n3/pnNzo7R9m84fMAaFenHRkP5T7zFVAqpjsMlCV9Y0yJtuPIDu/yyl0rvcv398z9ASwRYXL/yd71H8b8QL2q9dhx+w7W37Q+3y6c+88v/ENdpY0lfWNMsfv90O+M/3J8jvlnk9KSOP/183PUj7sljom9J+Z5vFvOucW73L1Jd8C5zdMzcNpdPe4C4P1h7/PCgBe8datWrFr0F1FKlP37k4wxJV6rF1sBsGLnCpbuWMrVna4mKS2JDzZ84K3zxdVf0P//+gPQslbLfI8XIRFsv307VaNyT+IPXPAAvU7t5X0Aq3uT7jluAy2rpCSPhBAbG6srV670X9EYU2qs3buWDnU7eG+P3Je4j/rP1Pe7n05QEk4kUK1StXJxP30gRGSVqsbmts1+c8aYsBn78Vim/TwNgBXXr6BapWq0f7m93/32/8t5Yja3Ga1M4VifvjGm0J774Tk2HthYqH1U1ZvwAR5b+pjfhF81qiqZD2VSp0qdIrXT5GRn+saYAjt04hC1n3IGM7vzyzvRCQXrHj6QdIC6T9fNUjZ/0/ws655j7U/cT3pmOrd+fivP9nu2TM1aVRLYmb4xpsBW7VpVoHpbE7Yijwhz18/lux3fZUn4nq4aj6+u+YqUB1K863Wr1qVhtYa8N/S9LAOrmeAoctIXkaYi8rWIrBeRdSJym1teS0QWisgW99+abrmIyAsiEicia0SkS7BehDEmdNIz0zlvxnnII8KHGz/Msu3jTR/nus+0VU43ztD3hmZ5oOqe8+6hTpU6VImq4i3r2qhrmZyhqqQK5Ew/HbhLVTsA3YGbRaQDcC+wSFVbA4vcdYBLgNbuz1hgSgCxjTFhMmnpJL7/83sApqzM+md7+ezLc92nySlNci1/9CJnHPwNN2/g7EZnM6jtIGpE1whia40/Re7TV9XdwG53+ZiIbMCZ/HwQcKFbbSbOOPv3uOVvurNlLReRGiLS0D2OMaYESc9MJ2piFIPbDfY7Ho2qZul3b/F8C/44/EeWOu8MeYfmNZp7z+ibVW/GihtWBL3dxr+gXMgVkeZAZ+BHoL5PIt8DeG7AbQz86bNbvFuWJemLyFicbwI0a9YsGM0zxvjhuROnRnQNGsQ04LJ3LgNg3sZ5Oeq+dMlLfLLlEz6Pc+aljXg0grFdxjL156l8+rdPsyT8LbdsoUFMA2IqxoT+RZgCCTjpi0gM8D5wu6oe9f3EV1UVkUI9/aWqU4Gp4DycFWj7jDF5U1XqPVOPA0kHAGeawa9Hfc2Xv3+ZpV6rWq2IOxQHOGPbvDf0Pc585Uy2JmwFYOrPUwG8HxYep9U8rVwMV1yaBPS/ISJROAn/bVX1PC+9V0QautsbAvvc8p2A76X4Jm6ZMaYYLNiygIhHI7wJH+DgiYP0frO3d/2MemcA8PGIjxnSfggAbWq3IaZiDJ+M+CTf4w9uN9gSfglU5DN9cU7pXwM2qKrvtPHzgVHAk+6/H/mUjxOR2cA5wBHrzzemePR6oxdLti/JdZvnQ2DJtUs4/9STg51NuWwKrWu15sLmFwLQvm57Eu5JoOZ/nKdkh58xnK+3fc2bV7xJv5b9QvsCTJEVeewdEekJLAXWAplu8f04/fpzgGbAdmCYqh5yPyReAgYAScB1qprvwDo29o4xwSePZH3Y6fh9x8nQDKatmsb4heO95QV98Co1I5W0jLRyMUJlaRGSsXdUdRmQ16NyfXKpr8DNRY1njCm4Ye8NI0MzeH/Y+1nKDycfzrJ+daervcn6rnPv4uZuN3PXF3fxZN8nCxyrYmRFu8++FLFhGIwpxYa8O4S0zDT+GftPLm19KeAMb/De+vcAyMjMyDLZ9+WznPvqr2h3Be9e9W6OOWajK0Tz8mUvh6n1pjhY0jemlLrwjQv5dvu3AHyy+RMWjVzEM98/w2dxn3nrVJhYgZ/H/kznhp2Z+O1Elu5YCsAHf/0g12Oass+SvjGl0AOLH/AmfI8+b+boVQWgy1Qb8cScZPdTGVMKPb70cQCe6P0EK29YSVTEyW6au8+9m/QH06leqXqu+34/+vuwtNGUTJb0c3HoxCFGvD8ix6Pk2aWkp9DyhZa89etb4WmYKTH2HN/DoROHii1+/5bOtIHjzx1P10ZdOfHvE/ylzV/o17Ifk/pOIjIikoR7Etg7fq93n2f7PYtOUHo07VFczTYlgJRme3sAABWQSURBVHXvALuO7SIjM8M7jGv36d3ZcmgLaRlpzB02N8/9vvnjG7YmbGXkvJFcc+Y14WquKWYPf/Mwj3z7CABP9X2Ku7+6m791/BtvD3k7ZDFX7lpJpmbSrXE3Bs8ezBe/fwHgvRAbGRHJ/BFZx6cXEepVrcevN/5KwokEejXvFbL2mdLDkj7Q+NnGgHNf8raEbWw5tAWAY6nHcq0/fO5wDp44yFdbv/KW3bLgFs5tei4jOo4IfYNN2Hkm6P734n9nmTHq7q/uBuCdte/w+qDXvbcupmemsz9xP1/8/gV7ju/h7vPuJvJR5y6a1AdSc9w1k93avWvZfHAzv+37jffWv8e6/ety1CnobZKd6ncqUD1TPtjE6Jx8WEUnKAu2LMgyfkj2B1R+2/cbHad0zPNYu+/aTWpGKs2q22BxZcHq3aupWbkmLZ5vUaD6o88azaJti9h+ZHu+9T4Y9gFXtL8i123VJlXjeOrxfPe/tdutPH/J8wVqkyl/8ns4y/r0ffy659ccA0Yt/H0hs9bO4sZPbmTVrlU5Er6nb9Wj4X8bcurkU5mxekbI22tC64u4L+gytUuOhP/1qK+9JwONqzUm9YFU77YZv8zwm/ABhswZkqNsyk9TkEckz4S/9LqlXNT8It4Z8o4lfFNk5f5Mf1/iPuo/Uz9Hecd6HVm7b63f/TMeyvB+bc/N+B7jeerip8rUPJ+Lti6i71t9uf2c23nkokeIqRjD3PVzObvR2bSomfOMOC0jzW93RknTe2Zvvv7j6yxlYzqP4Z7z7qF17dY56u86tsvbTQjOYGM3dr2Rc5uey6dbPmXE+yO4ot0VzL5qNpUeq+Stl3h/IsnpyUxbNY17F93rLZ9y2RSu6nAVERJBrcq1QvAKTVmW35l+uU/65752Lj/E/5Cl7JZut/DCJS/kGKPE4/S6p/PR8I84mnKUzg078/uh32n1YitevORF5q6fm+P+6ft63scTfZ4AIOFEAjUr1wzNiwmxtIw0Hv7mYZ5Y9kTedR5MY83eNZw97WzeGfIOw98f7t124t8niK4QnWOfTM1EkHw/GFPSU1izdw2xjWJJTEsk/mg8B5IOMHXVVHYe28lLl7xE2zptgzaqY4NnGrA3cS+vXf4aozuPLvB+1310Hec3Oz/HPr5Pxt74yY28uurVPI9xfefrmXb5tKI13Bgs6ecpNSOV9i+3944JDtC7RW8WjVwEwNz1cxn63tAs+7w95G3+1vFv+R536HtDmbs+610/f+/4d36I/8Eb66trvuJoytE8+3VLikzN5JWVr3DzgpuJlEgyNAMgy3JhdKrfiTV71wBwV4+7qBhZkUnLJgHQuUFnll+/PMsFSs+sTI2fbcyuY7v8Hn/m4Jl0qt+JtIw0YhvFkqmZ/LjzR5qe0jTLJNu7ju1i0tJJrN6zmh5NenBGvTNYsn0JP+/5mQEtB/Dkd08yqO0g5g3POYlIoJLSkqj6RO6Dk6U/mJ5l2ARjisKSfh48Z/I3dr2RKQOn8MnmT+jRpAe1q9T21tl4YCMNYxry5q9vMnvdbJZdt8xvV01yejJ7j+8lLTONi9+6ON/7/eNuiaNlrZZBeT3BoKrsOb6H+KPxdJveLcf2i0+7mHvOu4c+pzlPf6ZlpJGSkUJSWhK93uiV5c4WgGGnD2P2lbOJeLTgZ+BVoqoQUzGGfYn7EIRKFSrlOWXfR8M/omvDrtz55Z3MWTcn3+Ne1voyVu9ZXaAPj64Nu/LKwFeIbZTr301QeN5/k/tP5tZzbiVTMy3hm6AoUUlfRAYAzwORwHRVzXM4v2Ak/UzN5OZPb+aH+B84t+m53HT2TTSMaci327/lyjlXArD6H6s5q8FZAcXJy+5ju2n0bCPv+oK/LeDSdy7NUmdAqwG0r9OeG7rcQPu67YMWe/PBzURXiKZulbpUjqrsLc/IzOCTzZ8w+N3BAIztMtbbLfJ9/PfeM3GPW7rdwoGkAzzU6yHa1WnnN272OVMBthzcwl/n/pUn+jxBnxZ9GP/leFrUbMHIM0cSKZGICM8vf549x/ew8eBG1u9fT7s67Tin8TkkpiZSP6Y+N519k7d/OyMzAxHJ0p2zeNti9iXuY9OBTUxfPZ34o/EA9Dq1V44uN4DHLnqMO3rcQWpGKr/u+ZUVO1fQslZLGsY0DMsDTNsStrFsxzJ7xsMEXYlJ+iISCWwGLsaZI/cnYISqrs+tfjCS/l/n/jXfM8DFIxdzUYuLAopREGkZaURIBJERkcxZN4eRH44kJSMlR71hpw/jYNJBvt3+LemZ6Vm2Teg1gXHdxlGnSh2OpRwjITmBx5c8zjlNzmHaz9NYHr8ccO7fTs1IzXHsmtE1qRFdg22Ht/ltb/+W/bm3573eCTNKu2//+JaPN39My5otufasa7N8CBpT1pSkpN8DeFhV+7vr9wGo6qTc6rfr1E5f/PBFUjJSyMjM4HDyYQ4kHeBoylG+3f4t3Zt0JyU9xfvV/3DKYbYlbGP38d0cTz1OemY6R1OOAs644dsPb/eOMjim8xgm9JqQpZ+3OHy25bMcZ/7+1K9an72Je/1XBK7qcFWW6wsNYhpQu3Jtzm16LnWq1GHiRRP5ceePtKzZkuT0ZBpWa2hjoxtTypWkpH8VMEBVr3fXrwHOUdVxudZvJMo/8j9mtYrVvHeERFeIpmn1pjSr3oxTKp5CZEQkO47sYMagGdSrWg9wLt5GRUSVyFsoj6Uc4/O4z/nuz+8Y3Xm094LksdRjHEk+wpLtS/hx54/sPr6beRvnUa9qPfqe1pcr21/JxgMbue6s62hYrSGQs4sl+7jqxpiyq1QlfREZC4wFqNe0Xtf3l71PpchKREgENSvXpE6VOsRUjEFVLYkZY0wuQjJdYhHtBHz7U5q4ZV6qOhWYCk6ffs9mPXM/Usk7UTfGmBIv3MMw/AS0FpEWIlIRGA7M97OPMcaYIAnrmb6qpovIOOALnFs2Z6hqzuEDjTHGhETYh1ZW1QXAgnDHNcYYY6NsGmNMuWJJ3xhjyhFL+sYYU46U6AHXRGQ/4H9GCkcd4EAIm2PxLb7Ft/glNX72NpyqqnVzq1Sik35hiMjKvB5GsPgW3+Jb/LIcvzBtsO4dY4wpRyzpG2NMOVKWkv5Ui2/xLb7FL6fxoYBtKDN9+sYYY/wrS2f6xhhj/LCkb4wx5YglfWOMKQUkSDM/WdIvgmD98ktbfBGpUszxWxZHXJ/4UcUcP9L9t7h+/8X9vq/u/lsseUtETheR6OKI7QrKxM6lIumLyFkicoOINCim+D1FZIqI3ASgYb76LSLdRGSyiFwvIhHhjC8iESJSS0S+BP4FxfL6u4jIEuBJETklnLHd+N1FZDbwtIicUQzxzxORmcADIlKrmN5/04B7RCTXpzxDGDtCRE4RkU+AFwBUNTPMbegkIsuAx4Da4Yztxu8uIu8DL4tIP8+Hf1GV6KQvIlEi8irwGtALeFxEzglzG7oAU4BVwKUi8pyInBWm2FEi8izwKrARuBr4r7stLGdd7h9YOlAdOE1E+oYzvjvZzmPAu6o6VFWPhjn+UJz//0+AaODOMMc/Dfgf8DVwKjBRRC4LU+xIEZmEcyvgd0AXYIKI1A9HfPC+/44BUUBjEfmr27Zw5q4HgLmqeoWq7nTjh+v//0Kc//8PgE04OaBmIMcs0UkfOAOorqpdVfVqnPaGe3yLbsBPqjoduB5Iwkn+dcIQuxqwC7hMVV8BrgMGFsPZXgdgL7AU+IuIVA5j/C7AQVV9GUBEeohIpTDGbw18rKr/BzzntiEqjPG7AhtU9Q3gLuAXnPdA03z3Co4IYAcwzI1/O9CdIHUzFEI7nL/7ycDfRaSaqmaGOvG63zJOA46r6mS37GIRqYEzCVQ4kn9HnPzzNvAWzoff8UAOWOKSvjuVoqffTIBhIlJdRIbgvOH6iEhnt27Qf+EiMkxE7hSRc92in4EYEWmgqnuAxUBdII/Je4MS/y4R6aaqh4C3VXWXm+i2Aevc9oTkzebz+rv7FG8HfgM2A5nAgFB1tfnE7+ETu62I/EVEFgITgGkiMiJM8TcBQ0TkbuAHoBHO1+yQjLPifpVv41P0E9BERJqqagLOGfdhYEgY4mcCs1R1s/v+2wXE4wzsFRK+8X3e43FAKrDN/RklIs1C8cHrG9/9lnEAOF9ELhORecB4nG6mkHR15vL/vxQYKiIP4eSihsD/3G+gRVJikr6INBeRz4DpwNsi0kFVfwYeB15xf57AmVj9URFpE8xfuPtV9iHgHrfoVRH5C5AI/IHTvQTwLc4fXRN3v6Ak32zxFXhNRAar6m4AVU0RkUbAacDRELzZsr/+ae4HLcBZQBVVXYLz2l8EHhORCiF6/QBTReRKYD/wMU63ypOqOgCnq6O3iLQLRuw84k8TkctxvlbfBlwAjHTj7weuCuYHn4jUEJFPgYU4Jzox7qZkYBkwzF3fBKwHakkQLyrmFl9VM1T1MHjff9WAFjjfPoMql/hVfd7jsTjv+XU4Jz0TgCnidH8GJYflFh/A7U58HZiIM71rf5wc1T3biVGw48e48X8BBgDNgZtU9UKcD/4BItK+KLGKNelnSxjjgR9VtQ/OH/VEN7E/iPMffZWqvoXzFW8bcF4w26KqGUBb4C5VfRZ4BBiHM6XkLuAs94MoHecP7wp3v6Ak31ziTwBuzfYfexHO7+iwiFQNZhdTPvHb4Lz+RBF5HaeLaTOwRlXTQ/j6Hwb+ifPV/lfgdJw+dXC+bVXD+UAOijxe/x1AG1VdhJN8N7nVPwI6BTM+UBVn7uhb3OUL3PL9wHKgo/vtLwPYCZynqskhjH9+LnXOAda53zxjRKR1CONf4LNtB1BNRN4F7sa5vrZZVdOCeFE3v/if4CRdT1/6SpzuzpQgxc4tvvf3r6orcHoX/nCLAnr/F/eZfjSAiHjm6l0PoKov4fRljnY/yZNxz3RU9SDQ2FM3ECIyUkR6uX104PxH1hSRCqo6F/gduBjnl5yMc0ERN/5PPu0ORfwPcF7jX+XkrYLVgNUiMhpYjXMGFMr464DBOG+4/sBR4EzgaaCziDQPYfz3cT5cLsc5030KuM19P1wM1ML5Pwll/HXACPeM/nfgKrde50BjZ4t/inuBcCowxz12NxFp7Cb5H3D+v59zzwBPB3aIewttiOKf436z9P37rAH8KSLX4XQ7BXRDQ0Hj4yTbusAenN/9P3G6/Ip0pluI+I0BVHUNTnfOOPdE62qc640HQxzf8/uvBHwP3Ozu2gfnLqIivQeLZewdEbkY5xN7E7BEVeeIyKM4Fylmu9UeB47gfK2KwPm0fR+nX38ncIuq7i9CbAEaAO/g9Fn+jvPJ+g/gVpwz+xfcs+l2bnv6q+peEZkB1AfqASNUNS7E8dvivAkGqOpuEVmM8w1nNvBf980Yyvjt3Xr9gBSfO2caAulh+v2/6/P6J+H0qTcFblbVDWGIPxvnQ6YTzh9dI5wLaeNUdWMQ49+mqgfcOufhnOSsdL/devZ9Fqdb8VScrqZNFFIh4//kXsD27PsW8HdgJvBckN9/+b5+Eanjsz0GqOhe8wpLfLf8Tpzu1dbAHapa6BPPAF7/6TjfPhsAaTjvv0K//wFQ1bD+AK2AH4FBOJ/as4CbcM5iH8RJ7stwzmJnuS8OnLOKfwBXBBA70v23DfB/njKcW/Jm4JzJfI7z1a6Ku30Ozn8wOB9KdcMc/13gdnf5DmBwMbz+29zlCCCiGF7/ne6yADFhjv8eTl8qQAzQMQTxXwQ+yFb3DpxvltWBaj51q4U5/ime3zkwHKebNdyvv6pP3VC8/wr0+3fLo8IcvwZQ2S2rDJxW1Pien4C6JwrKc7FFnf63c4BVqvqRu+0rnHvP31PViSJymqpudbd9h/sVRp0LGr8UMX4kzjeGSBFZgPNGznCPmyEi44DdbjvewXlzN8RJOGk4X61Q1TScPtZwxk/H+XqPqj5XhJcfjNe/3K1bpP7TILz+79y6ShFuVwswfipOHzKqehxYG4L4twG7RKSXqn7r7jYN549+IXCqiHRW5+6ZY2GOvwhoJiJnqersXA4f7tdfrPHdHBDu+M1EpIs6XUBbi/I78BXyPn23/y8e50WD80czXERauOsVcL7ieBLaNne/scBonNuUAonfC+ePtibOrV8TcRLZRSLSDbwX8R4BnlbVN4EvgZEistptX6H/0C2+xS9E/EycC9cP++x6Gc434F9xvl0UNeEFGv8XN/7uYopf3K+/uON7fv87ixI/V4F+VfDzdSYGmIdzy9vPQDu3fDJO1813wP/hPIDwKVDf3X47zoWis4PQhvOBa3zW/4dzIehanG8c4Hz4NQDmAk3dsgYE4auUxbf4hYg/B2julg0CLrD4Fj/YP0E/YC4vupn775M4j9KD049VC+jprjcF3gAquetVghi/ClCJk/1pfwcmucu/4FwQBvcaQghev8W3+Bbf4hdL/Nx+Qt69o6o73MXJQAsR6a/O1+kjqrrM3XYjzvAG6e4+SUGMn6SqKW5McO7E8PTLXwe0F2cwp1kE2JVk8S1+MOK7d3hYfIsfGuH4ZPH51PsH8K3PejecB10WAA1CHDsS52vUZ0Art6wVztXxnkBji2/xLb7FL4vxfX/C9nCWOEMCvwrsF5EXReQZnC6eO1X1UnXGtQmlTJxbLg8AndxP1weBTFVdpsG8UGLxLb7Ft/glK/5J4fp0cT/ZqgBL3Bd+azhju/G7u7/8ZcAYi2/xLb7FLy/xPT9hfSJXRMbjPFF4j6oGc9yKgsZvAlwDPGvxLb7Ft/jlKb63HWFO+hEa5llvjDHGnFQsY+8YY4wpHsU9yqYxxpgwsqRvjDHliCV9Y4wpRyzpG+NDRDJE5BcRWSciv4ozX3G+fyfiTPX5t3C10ZhAWNI3JqsTqnqWqp6O88j8JTiTV+SnOWBJ35QKdveOMT5E5Liqxvisn4Yz4msdnBmr3sKZ6QicCX6+F5HlQHucYcFnAi/gDDB4Ic5gWy+r8zS6McXOkr4xPrInfbfsMM6k6cdwHptPFmdS8FmqGisiFwLjVXWgW38sUE9VHxNnftPvgKGqui2sL8aYXIRl5ixjyogo4CUROQtn5qM2edTrhzO+imci9eo486pa0jfFzpK+Mflwu3cygH04fft7gTNxrocl57UbzjjpX4SlkcYUgl3INSYPIlIXeAV4SZ1+0OrAbncokWtwhssFp9unms+uXwD/FJEo9zhtRKQqxpQAdqZvTFaVReQXnK6cdJwLt8+62/4HvC8iI4HPgUS3fA2QISK/4swA9zzOHT0/uxNi7AcGh+sFGJMfu5BrjDHliHXvGGNMOWJJ3xhjyhFL+sYYU45Y0jfGmHLEkr4xxpQjlvSNMaYcsaRvjDHliCV9Y4wpR/4fYmpbE3HB+k0AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "df['Adj. Close'].plot(color='g')\n",
-    "plt.legend(loc='upper left')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 72,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "forecast = 30\n",
-    "df['Prediction'] = df[['Adj. Close']].shift(-forecast)\n",
-    "\n",
-    "X = np.array(df.drop(['Prediction'], 1))\n",
-    "X = preprocessing.scale(X)\n",
-    "\n",
-    "X_forecast = X[-forecast:]\n",
-    "X = X[:-forecast]\n",
-    "\n",
-    "y = np.array(df['Prediction'])\n",
-    "y = y[:-forecast]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 73,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1502.87348213 1541.7866017  1553.19217124 1539.27332961 1560.21016406\n",
-      " 1575.72642439 1577.68592466 1593.91569867 1617.29125901 1606.67374937\n",
-      " 1607.1742739  1586.94030367 1594.18193512 1619.05906904 1634.00025863\n",
-      " 1641.83825973 1649.14378792 1677.92927293 1698.69571605 1687.82261942\n",
-      " 1690.82576658 1681.58203703 1670.2510137  1641.76371352 1686.04415993\n",
-      " 1681.09216196 1640.8798085  1589.18733931 1653.40357113 1590.77410856]\n"
-     ]
-    }
-   ],
-   "source": [
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)\n",
-    "\n",
-    "clf = LinearRegression()\n",
-    "clf.fit(X_train, y_train)\n",
-    "\n",
-    "confidence = clf.score(X_test, y_test)\n",
-    "\n",
-    "forecast_predicted = clf.predict(X_forecast)\n",
-    "print(forecast_predicted)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 91,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(736445.0, 736810.0)"
-      ]
-     },
-     "execution_count": 91,
-     "metadata": {},
-     "output_type": "execute_result"
+      "execution_count": 4,
+      "outputs": []
     },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAEFCAYAAAAFeFvqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8li6FKAAAgAElEQVR4nO3dd3hU1dbA4d9KISF0Qi+hg4j0XATFiogFwYZgAxVBULnqtbdPFPV6rYhcUFSuKGIBFBBUVKQoSAlKRyAQIEQ6gdDS1/fHOYlDC0mYZDIz632eeZjZp2StTJg1Z+99zhFVxRhjTHAK8XUAxhhjfMeKgDHGBDErAsYYE8SsCBhjTBCzImCMMUHMioAxxgSxsIJuICJjge7ALlU9x237AmjmrlIR2K+qbUSkPrAWWOcuW6iqg9xt2gMfAaWBb4EHNB/zVatUqaL169cvaNjGGBO0li5dukdVq55sWYGLAM4H90jg45wGVe2d81xE3gAOeKy/UVXbnGQ/o4EBwCKcInAF8N3pfnj9+vWJi4srRNjGGBOcRGTLqZYVuDtIVecB+07xgwS4CfjsNAHVBMqr6kL32//HwLUFjcUYY8yZ8faYwAXATlXd4NHWQET+EJG5InKB21Yb2Oaxzja3zRhjTDEqTHdQXm7m2KOA7UCMqu51xwCmiEiLgu5URAYCAwFiYmK8EqgxxhgvHgmISBhwPfBFTpuqpqnqXvf5UmAj0BRIAup4bF7HbTspVR2jqrGqGlu16knHNowxxhSCN7uDLgP+VNXcbh4RqSoioe7zhkATYJOqbgdSRKSjO47QF5jqxViMMcbkQ4GLgIh8BvwGNBORbSLS313UhxMHhC8EVojIMmASMEhVcwaV7wU+AOJxjhBOOzPIGGOMd4m/XUo6NjZWbYqoMSbYZWWlsn//bCpXvgKnQ+XURGSpqsaebJmdMWyMMX4oIeFpVq68ij//7MvWra+jmg2AahYF+XJvRcAYY/xMdnYaO3c65+vu3DmeTZseZePGhwH4/ffzWLiwPocOrcrXvrw9RdQYY0wR27PnGzIy9tCy5QxKl25KUtI7bNs2nMjIhhw8uBiAxMRXad7849PsyYqAMcb4nb17pxEWFk2lSpcTEhJGo0ZvcPDgYuLjHwQgJCSSlJRF+dqXdQcZY4wfyc7OZO/eGURHX01IiPM9PiQkjJo1BwDOuECtWvdy9Oh60tKSiI//V577syJgjDF+Ijs7k/j4IWRm7qNKlWMvtxYd3R0QIiLqus8hMfENtm17K899WneQMcb4AdUsVq++gb17p1G37mNUqdLzmOWlSlUjOvoaSpWqSblyzmzQXbu+PO1+rQgYY4wf2L59LHv3TqNRozepW/ehk67TsuXfF16IjGxAamrCafdr3UHGGFPC7Nr1BStX9iAz8yAA2dnpJCQ8Q4UKF1CnzoP52keZMvm7VqcdCRhjTAmiqqxbN5CsrBSWLDmH6tVvo3z5jmRk7CIm5n+nPTs4R5ky57B37/TTrmdHAsYYUwipmak8+P2DdP2kKzsP7SQ1M9Ur+z14cDFZWSlUqnQZYWHl2br1P2zd+rI7JbRrvvcTFeUcCYiE57meFQFjjCmg9XvX0+nDTry96G1+TviZGm/UoNXoVmxL+fteWYfTD/PID4/wy5ZfCrTvxMTXCQ0tS4sWk2nZcjqQRUrKQmrUuIOQkLw/0D2VKXMOABUqdM5zPSsCxhhTAKt2raL9mPZsPbCVb27+hi9u/ILBsYPZcWgH3cZ3IyUtBYBvN3zLG7+9wYUfXcja3WtPu9/MzBTi4x9m9+5J1K37KGFh5YmMrEf9+sOoV+8ZGjZ8pUBxli3bmsaNR9C48Yg817MxAWOMKYCxf4wlPSudVYNXUa9iPQBuPPtGbjz7Ri7/5HJu+PIGvrn5GxYnLc7dZlbCLJpXbZ7nfhMSniEpaSTR0d2pU+fvE7zq13+mUHGKCHXqDDntenYkYIwx+aSqfLX2K7o27JpbAHJc2uBSPuzxIbM2zeK6L67j18Rf6VC7A3XK1+HXrb/mrrdq1yqW7ViW+zoz8yBHj27kr79GU6vWPbRs+Q1hYWWLLSc7EjDGmHxQVUYsGsGWA1t47qLnTrpOvzb9yMjOYMA3AwAY0mEIuw7vYn7ifACysrPo8VkPKkZW5Pd7ficlZTHLll1EeHgVAOrVe7Z4kvFgRcAYY05DVRk0fRBjfh/D1U2u5uaWN59y3bvb3U1mdiaDZwymS4MubD2wlS9Wf8G2lG3E/RVHwv4EosKjyMrOYs2am8nOTiUtbRtVq/YmIqJWMWblKFR3kIiMFZFdIrLKo22oiCSJyDL3cZXHsidFJF5E1olIN4/2K9y2eBF54sxSMcaYovHRso8Y8/sYHun0CFP7TCUyLDLP9QfFDmLPo3voeVZP2tZsC8DyHct5e9HbABzJOMKm3b+SmrqJhg3/Q3T0NdSr91SR53EyhR0T+Ai44iTtb6lqG/fxLYCInI1z/+EW7jajRCTUvQH9f4ErgbOBm911jTGm2L0b9y6dx3Zmy/4tx7QvSFzAQzMf4vy65/Ofrv8hNCQ0X/uLjooGoGW1lgB8suIT5myewxWNnY/OZYkznPWir6Fly2mULdvKW6kUSKGKgKrOA/addkVHT+BzVU1T1QScG8t3cB/xqrpJVdOBz911jTGm2GRmZzLk2yEMnjGYBYkLaP1ua7pP6E62ZjPlzyl0+bgL1cpUY/z14wmRgn9kVoisQL0K9fhi9RdEhUfx6mWvArBm5wLCwioSFdXM2ykViLdnB90vIivc7qJKblttINFjnW1u26najTGmWKRlptF9QndGLhnJI50e4de7fuX8mPOZsWEGV316FTd8eQOtq7dm/l3zqV+xfqF/Tqvqzrf8fq370aJaC6LCo1i350/Kl++EFKKweJM3f/pooBHQBtgOvOGtHYvIQBGJE5G43bt3e2u3xpggN3zhcGZunMl73d/jtctf47y65zGl9xTKlSrHzI0z6d60Oz/3+5mqZaqe0c9pV7MdAP8895+ESAhNKjdhe3oFqlXr7Y00zojXZgep6s6c5yLyPpBz5aIkoK7HqnXcNvJoP37fY4AxALGxseqlkI0xQSojK4Pbv76dr9Z+RY9mPRjYfmDusvDQcL65+RvW7lnLwPYDC9UFdLwHOz5I14ZdOavKWQB80OMDKpeuTI1KDc9432fKa0VARGqq6nb35XVAzsyhacAEEXkTqAU0ARYDAjQRkQY4H/59gFu8FY8xxpzKO4vf4YvVXzCg3QCGXTLshOUX1b+Ii+pf5LWfVzGyIufHnJ/7OrZWrNf2faYKVQRE5DPgYqCKiGwDngMuFpE2gAKbgXsAVHW1iHwJrAEygftUNcvdz/3ATCAUGKuqq88oG2OMOc6fe/5kzuY53NP+HrYf2s7TPz/NuGXjuLrJ1bzX/b18X5o5UImqf/WuxMbGalxcnK/DMMYUsyMZR/h4+cf0b9uf8ND8XU1z56GdtB/TnqSDSdx49o18u+FbMrMzefDcB3n6wqcpH1G+iKMuGURkqaqe9PDDzhg2xviFWybfwtR1U6ldrjbXNLsmt/2HjT+Qrdm58+89vf/7+yQdTKJ19dZMWjOJm1rcxCtdXqFBpQbFGXqJZkXAGFPird29lqnrnPvnrt69mipRVehUtxMA3cY7FyHI+r+sEwZx522ZxznVzmHuHXPZlrKNFtXyd8vFYGJXETXGlHhvL3qbiNAIAIbNG8Z5Y8/j81WfczTjaO46CxIXHLNNZnYmv237jQtjLqRCZAUrAKdgRcAYU2JlazZj/xjLuOXjuK3VbbSr2Y4jGUcAuHva3UxcMzF33YmrJx6z7bIdyziUfogL6l1QrDH7GysCxpgSafmO5Zz34Xn0n9afdjXbMfTioTSu3BiAS+pfQlR4FP2n9QegVrlaLN+5/JjtZ8bPBOCiet6b6hmIrAgYY0qczOxMrppwFQn7Exh37Th+vfNX6pSvQ+NKThHo2awnE26YQFZ2FhUiKnBpg0vZlLzpmH1MWTeFDrU7ULNcTV+k4DdsYNgYU+LM2jSLvw7+xaRek7jh7Bty25tGNwXg3Drn0rFOR0ZdPYrko8mkZaXx6YpPSctMIyIsIvfa/S9f+rKvUvAbVgSMMSXOJys+oWJkRbo37X5Me+9zehMVHsW5tc8FnOv2A3y8/GMUZeuBrTSJbsIrv75CqIRyU4ubij12f2NFwBhTYmRkZZCYksjENRMZ0G4AEWERxyyPDIukV4teJ2zXoKIz739T8iayNZt3495lUOwgGlVuVCxx+zMbEzDGlBhPznqSRiMakZ6Vzv0d7s/3dg3dC7FtSt7E4z89TlR41CnvA2yOZUcCxpgSY/LayYBzg/acK27mR81yNYkIjeCj5R+xOGkx/+7y7zO+/HOwsCMBY0yJsP3gdjbv38xrXV9jxJUjCrRtiITQt3VfFictpm75ujxw7gNFFGXgsSMBY0yJMHfLXKDw8/qHXzGcIxlH6Nu6L6XDS3sztIBmRcAY43MHUg/w3JznqFG2Bm1rti3UPqLCoxh//XgvRxb4rAgYY4pcWmYaWw9sJURCCJEQIsIiqFWuFuBcGuK2r29jU/ImZvWdRViIfSwVJ/ttG2OKXL8p/fhi9RfHtN3d9m7GXDOG5+c8z/T103nnyne4sN6FPooweFkRMMYUqSMZR5i2bhrXNL2GXmf3IkuzWLRtEe8ufZcJqyZwJOMId7S5g/v+cZ+vQw1KVgSMMUVq1qZZHM08ypAOQ+jaqCsA/Vr3o3NMZ5b8tYT6FeszKHZQ0N/m0VcKXAREZCzQHdilque4ba8B1wDpwEbgTlXdLyL1gbXAOnfzhao6yN2mPfARUBr4FnhA/e1el8aY05q8djLlI8ofc+N2EeHWVrdya6tbfRiZgcKdJ/ARcPx93H4EzlHVVsB64EmPZRtVtY37GOTRPhoYADRxHyfeG84Y49cOpB5g4pqJ9GnRh1KhpXwdjjmJAhcBVZ0H7Duu7QdVzXRfLgTq5LUPEakJlFfVhe63/4+BawsaizGm5JqdMJuen/fkSMYR7m53t6/DMadQFGcM3wV85/G6gYj8ISJzRSTnFj+1gW0e62xz205KRAaKSJyIxO3evdv7ERtjvOZw+mHu//Z+Lv34UuL3xfNU56eIrRXr67DMKXh1YFhEngYygU/dpu1AjKrudccApohIgW/0qapjgDEAsbGxNm5gTAn1y5ZfuGPqHSQkJ/DguQ/yUpeXiAqP8nVYJg9eKwIicgfOgHGXnAFeVU0D0tznS0VkI9AUSOLYLqM6bpsxxk+t27OOSz++lJgKMcy5Y47N+fcTXikCInIF8Bhwkaoe8WivCuxT1SwRaYgzALxJVfeJSIqIdAQWAX2Bd7wRizHGN95a+BahEsr8u+ZTo2wNX4dj8qkwU0Q/Ay4GqojINuA5nNlAEcCP7lzfnKmgFwIviEgGkA0MUtWcQeV7+XuK6HccO45gjPEjry94nbF/jKVv675WAPyM+NvU/NjYWI2Li/N1GMb4lKqyOGkxE1ZOICIsgkfPe/SMr5+fmZ1JelZ6gfvwf9nyCxd+dCE9mvXgfz3/R+XSlc8oDuN9IrJUVU86Om9nDBvjZ76P/56HZj7En3v+JDIskoysDPYc2cPYnmMLtb/dh3fz3tL3GLVkFHuP7mVQ+0G8dcVbhMixkwczsjKYsHIC6/auY9glwwiREGZsmMGQ74ZQp3wdPrvhMxsE9kNWBIzxI8lHk7ntq9uIjormg2s+oFeLXvSf1p9p66bx5E9PMqD9gNxbLZ5OamYqz/78LO8sfoe0rDS6NepGjbI1GLF4BJsPbOaZC56hdY3WxP0Vxy9bfuHTlZ+yctdKAEIllAXbFvBzws80qdyE8deNtwLgp6wIGONHnpvzHMmpyczqO4vWNVoD0LVhVyatmcQr819hfuJ85t4x94Tr8BxIPcDcLXOZtWkWC5MW0r5mexJTEpm+fjr9Wvfj8fMfp3nV5qgqDSs1ZPjC4XRa34nw0HBSM1MBaFG1BZN6TeLlX1/mxV9eJLp0NCOuGMGg2EGEh4YX++/CeIeNCRjjJ1btWkWbd9twT/t7+O/V/81t37x/Mw3ebpD7+oWLX+DZi54FnCt4Dpo+iE9Xfkq2ZlM6rDRta7Yl7q840rPSeb3r6zx83sMn/Kz9qft5Ye4LqCoX1LuAzjGdqVamWm4cM9bP4J7Ye6gYWbGIszbekNeYgBUBY/xE9wndmZ84n/gh8URHRR+zbNq6aXSq04lHfnyEj5d/zKirRjGw/UC6f9admfEzeeDcB+h5Vk861elERFgERzKOcCj9UO4HuwlsNjBsjJ/4ceOPVIysyJrda2hdozVtarQBnBk4MzbM4N9d/n1CAQDo0awHAB9c8wHJR5O579v7mLhmIrM3z+a97u8xsP3AY9aPCo+yPnwDWBEwxieSUpKYtGYSq3evpnNMZ5JSkli5ayWfrfqMsJAwMrMzKR1WmmuaXUOjSo2YtGYSMRViGNJhSJ77DQ8N54sbv6Db+G7M3jyb5y567oQCYIwn6w4yppjkfPBPXDOR+YnzAecb+ZEM5yT7GmVrcHWTq5mzeQ6tqreiVGgplm5fyub9m8nWbGbeNpPLGl6Wr591JOMI6/asK/RN201gse4gY4rRip0r+GjZRxxIPcCj5z9Ks+hm3P717Xy60rmuYqvqrXjxkhfp1aIXMRVi2LB3A/Ur1qdcRDnAOWkrVEJzZ/hkZmdyMO0glUpXyncMUeFRVgBMvlgRMMZLEg8kct0X17F0+1LCQ8IJCwlj7LKxNI1uyvq96xnUfhAPdnyQZlWaHbNdy+otj3kdFhJ2wuuCFABjCsKKgDFe8uvWX1m6fSnDLhnG4NjBHMk4woSVE3jq56eIqRDD21e+bXfXMiWOFQFjvCQ5NRmAge0HEh0VTTTRPN75cTrV7UTFyIpWAEyJZEXAGC/Zd9S5QG6lyGO7buy6+qYkK4rbSxoTlJKPJlMmvIxdQsH4FSsCQeq7Dd8xdM5Q0jLTfB1KwNiXus8uo2z8jnUHBZm0zDTmbplL70m9OZh+kJW7VjL5psm+DisgJB9Ntlk8xu/YkUCAU1V2HNpBamYq78a9S+N3GtNtfDdEhNtb3c6UP6ew49AOX4cZEPYd3XfCeIAxJV2hioCIjBWRXSKyyqOtsoj8KCIb3H8rue0iIiNEJF5EVohIO49t+rnrbxCRfmeejsmhqjz6w6PUeasONd+oSYVXKjB4xmDqlq/LVzd9xYYhG3j8/MfJ1my+WvuVr8MNCMmpydYdZPxOYY8EPgKuOK7tCWCWqjYBZrmvAa7EucF8E2AgMBqcooFzf+JzgQ7AczmFwx+kZaaxbMcyFm1bRHpWOst3LCf5aLKvw8o1fsV4Xv/tddrWaMt/LvsP/Vr347tbv2P+XfO5rvl1VCtTjRbVWnBOtXN447c3SlTsJZGq5l5X/1SSjybbkYDxO4UaE1DVeSJS/7jmnjg3oAcYB8wBHnfbP1bnIkULRaSiiNR01/0x58bzIvIjTmH5rDAxFZct+7fQa2Ivft/+O1maBUDNsjXZfmg7zas0Z819a/K1n837N7P0r6UkpiRSs2xNejTrQenw0oWK6bsN3zEqbhT3/+N+lvy1hCl/TmHp9qX8o9Y/mNpnKqEhoafc9r3u73HxRxfTZ3IfZtwy44SzVUuSrOwsROSE2x4WheU7ljN3y1zi98WTsD+BZTuWcSj9EIvuXkTT6KYn3WbfURsYNv7Hm//jq6vqdvf5DqC6+7w2kOix3ja37VTtPrfj0A7e+u0tVu9eTVpWGmmZaaRnpRNTIYZlO5ax6/Aunuj8BK2qt2LWpllMWjuJjnU6snDbQjbu20ijyo1O2KeqsnLXSr6P/57tB7czbvm43JOLACpEVKDPOX34d5d/ExUeRURYxGnj/D7+e96Ne5d5W+aRnJrM9PXTAehYpyOvdHmFu9relWcBADiv7nmMvno0d39zN/fNuI+D6QdJz0rnxUtf5KwqZ+WudzTjKBFhEcXyAXwqfaf0ZUHiAqb0npJ7Vy1vOJB6gJS0FFLSUqhRtgb/N/v/GBU3CoBypcrRoFIDOtXpxOzNs7nhyxtY2H8hZUqVOWYfqZmpHM08agPDxu8Uydc+VVUR8drlSUVkIE5XEjExMd7a7UllZWdx45c3sihpES2qtsj9QC4XVo4lfy2hXKlyTLppUu7VHG9qcROjrh7FpuRNNB3ZlJkbZ3Jv5XsBOJx+mKjwKDbs20C38d3YvH8zAKVCSxFdOprZ/WbTqFIj1u9dz7jl4/jg9w9YuG0hG/Zt4NtbvuWi+hedNMaUtBQenvkwH/zxAdXKVCMqPIqve3/NgbQD/KPWP6hZrmaBcu7frj/Ldixj5JKRlA4rTWRYJOd9eB41ytYgOTWZ5KPJpGWlcVaVs5hxy4zce9imZaYxbd00IsMi6da4W4HPiM3KziI9Kz1fR0CLti1iwsoJAPzj/X9wf4f7efS8Rwucq6eMrAzumHpH7n4BBEFRHur4EA93epha5WrlXsjtp00/cfknl3P9l9fzetfXj7nmT053mnUHGX/jzSKwU0Rqqup2t7tnl9ueBNT1WK+O25bE391HOe1zTrZjVR0DjAHnUtJejPkYB1IPMGzeMOYnzmfctePo27pvvrYLDQmlceXGNKjYgNFxozm39rlULl2ZVu+2oknlJlSJqsKOQzv4sMeHXNH4CipFViJLsyhbqiwAdSvUpUvDLkSFR/He0vcAGDRjEIvvXpx7ZUlwisrRzKN0/KAjCfsTeOy8x3j+kueJDIs849zf7PYmlUtX5qomV1EuohzPzn6WEAmhUmQlKkVWokypMgxfOJx+U/ox7455fLP+G/41819sTN4IQJPKTVjQfwFVoqrk+2feOfVOJqycwIX1LqRv677c0PwGykWU44/tf9B7Um/eufIdGlVuxKvzX2Xc8nFUjarKwrsX8tK8lxixaASjloyif9v+3NfhPnYd3sUFMRec9sjH07Ozn2XCygk8cO4DtKzWkqjwKOZumUvnmM7c1uq2E9a/rOFljLxqJI//9Dht32vLQx0f4ukLn2b4wuEcSj8EYN1Bxv+oaqEeQH1glcfr14An3OdPAK+6z68GvgME6AgsdtsrAwlAJfeRAFQ+3c9t3769FsahtEOanZ2tqqrT/pymM+NnqqpqZlamTl83Xa/69CqVoaIMRe+dfm/uugXx5aovtdIrlZShaO03aitDyX30+rLXabdPSknS3hN76zuL3tHQ50O19ejWOn/rfFVVXb1rtVZ/rbqWfrG0hj4fqj9v+rnA8Z2pl+a9pAxF277bVhmKNh/ZXKevm66TVk9SGSr6xI9PHLP+yEUjdfKaySfd15S1U5Sh6JXjr9TGIxorQ9Gol6K0z6Q+GvNWjDIULfdyOQ15PkRLDSulg74ZpAnJCbnbx++N1wHTBmj4C+G5v+P+U/trVnbWSX9eakaqpmak5r5ev2e9lhpWSvt93a/Av4d9R/bpgGkDlKFo6RdLH/M+/7rl1wLvz5iiBsTpKT5TC3VTGRH5DOdbfBVgJ84snynAl0AMsAW4SVX3iXMsPRJn0PcIcKeqxrn7uQt4yt3tS6r6v9P97ILcVGbHoR1UK1ONkYtH8sD3D1A+ojwxFWJYtcuZ2Tqw3UCmrJvCrsO7qFG2Bne2uZNOdTrRvWn33C6AgjqQeoDhC4fz1sK3eOS8R2hepTk3TryR2f1mc3H9i/O9n+82fMdd0+5ix6EdXHfWdSxIXICIEB4SzoB2A3JvJF6cNiVvotEIZ7zj5Utf5pHzHsm9RMLNk29m8prJnB9zPu1rtie6dDRP/fwUgvBq11d5qONDud/S9x3dR4tRLahepjpLBiwhLCSM37b9xrhl45i0dhK1y9VmUOwg3vztTa476zr+1elfp+z2STyQyMQ1E0lITmDkkpEMjh3M8CuG53ZNpWel8/bCt3lh3gscSj9E+Yjy1Chbg5S0FFIzU1l972pqlatVqN/HvC3zeOzHx+jdojddG3XlaMZRYmvFFvpvx5iiErA3mp+2bhoTVk6gc0xn7ml/T+4H0vIdy3ly1pN8F/8djSo14q+Df9G2Zlva1WjHpv2b2Hpga24h6NmsJ7e2vJVrz7rWq9d8yfm9igiH0g/ldv0UxOH0w7z525u8uuBVyoSXYc4dc2gW3cynHzKDpw8mpkIMT17w5DHtuw7v4uVfXmZB4gJW7FxBWlYaTSo34eyqZzN13VQua3gZPZv1JC0zjc9Xf86yHctYfPdir934RFV5/KfHeW3BazSLbsZb3d6iS8MuXDLuEhYkLqB70+6cW/tcdh/eTWJKIruP7GbEFSPsxismKARkERi5eCT//O6fVIysSHJqMk0qN2FAuwEs37mcCSsnUCGyAgPbDWTFrhXsO7qPSb0mUbeCMzSRrdmcM+ocqpapyux+s3064yU/9h3dR7ZmF6i/3ZcysjJYu2ctNcrWoGpUVT7840Pu+/Y+0rPSAWfGzfjrx+feHN2bZqyfwUMzH2LDPuduXZv3b+Z/Pf/HHW3u8PrPMsZfBFwR6PpKV16Z/wrXnnUtE66fwA8bf+DVBa+yIHEBpcNK88C5D/DY+Y/lOV3vQOoBwkPDiQqPKsbog9fBtIOkZqYSERZBVHhUkZ6PkJ6VzjuL3mH6hul0rtuZYZcOK7KfZYw/CKgiUKFhBU3pl8Kg9oMYedXIY2aDbNy3kXIR5ahWppoPIzTGmJIloG40n5KWwuirR3NP+3tO6Bs/2UlaxhhjTs3vjgQatWikG1dv9HUYxhjjN/I6EijZI6InYaflG2OM9/hdETDGGOM9VgSMMSaIWREwxpggZkXAGGOCmBUBY4wJYlYEjDEmiFkRMMaYIGZFwBhjgpgVAWOMCWJWBIwxJohZETDGmCDmtSIgIs1EZJnHI0VEHhSRoSKS5NF+lcc2T4pIvIisE5Fu3orFGGNM/njtUtKqug5oAyAioUAS8DVwJ/CWqr7uub6InA30AVoAtYCfRKSpqmZ5KyZjjDF5K6ruoC7ARlXdksc6PYHPVTVNVROAeKBDEcVjjDHmJIqqCPQBPvN4fb+IrBCRsSKScy3o2kCixzrb3PE0vpQAABF+SURBVDZjjDHFxOtFQERKAT2AiW7TaKARTlfRduCNQuxzoIjEiUjc7t27vRarMcYEu6I4ErgS+F1VdwKo6k5VzVLVbOB9/u7ySQLqemxXx207gaqOUdVYVY2tWrVqEYRsjDHBqSiKwM14dAWJSE2PZdcBq9zn04A+IhIhIg2AJsDiIojHGGPMKXj1RvMiUgboCtzj0fyqiLQBFNics0xVV4vIl8AaIBO4z2YGGWNM8fJqEVDVw0D0cW2357H+S8BL3ozBGGNM/tkZw8YYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPErAgYY0wQsyJgjDFBzIqAMcYEMSsCxhgTxKwIGGNMELMiYIwxQcyKgDHGBDErAsYYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPEvF4ERGSziKwUkWUiEue2VRaRH0Vkg/tvJbddRGSEiMSLyAoRaefteIwxxpxaUR0JXKKqbVQ11n39BDBLVZsAs9zXAFfi3GC+CTAQGF1E8RhjjDmJ4uoO6gmMc5+PA671aP9YHQuBiiJSs5hiMsaYoFcURUCBH0RkqYgMdNuqq+p29/kOoLr7vDaQ6LHtNrfNGGNMMQgrgn12VtUkEakG/Cgif3ouVFUVES3IDt1iMhAgJibGe5EaY0yQ8/qRgKomuf/uAr4GOgA7c7p53H93uasnAXU9Nq/jth2/zzGqGquqsVWrVvV2yMYYE7S8WgREpIyIlMt5DlwOrAKmAf3c1foBU93n04C+7iyhjsABj24jY4wxRczb3UHVga9FJGffE1T1exFZAnwpIv2BLcBN7vrfAlcB8cAR4E4vx2OMMSYPXi0CqroJaH2S9r1Al5O0K3CfN2MwxhiTf3bGsDHGBDErAsYYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPErAgYY0wQsyJgjDFBzIqAMcYEMSsCxhgTxKwIGGNMELMiYIwxQcyKgDHGBDErAsYYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPEvFYERKSuiMwWkTUislpEHnDbh4pIkogscx9XeWzzpIjEi8g6EenmrViMMcbkjzfvMZwJPKyqv4tIOWCpiPzoLntLVV/3XFlEzgb6AC2AWsBPItJUVbO8GJMxxpg8eO1IQFW3q+rv7vODwFqgdh6b9AQ+V9U0VU0A4oEO3orHGGPM6RXJmICI1AfaAovcpvtFZIWIjBWRSm5bbSDRY7NtnKJoiMhAEYkTkbjdu3cXRcjGGBOUvF4ERKQsMBl4UFVTgNFAI6ANsB14o6D7VNUxqhqrqrFVq1b1arzGGBPMvFoERCQcpwB8qqpfAajqTlXNUtVs4H3+7vJJAup6bF7HbTPGGFNMvDk7SIAPgbWq+qZHe02P1a4DVrnPpwF9RCRCRBoATYDF3orHGGPM6XlzdtD5wO3AShFZ5rY9BdwsIm0ABTYD9wCo6moR+RJYgzOz6D6bGWSMMcXLa0VAVX8F5CSLvs1jm5eAl7wVgzHGmIKxM4aNMSaIWREwxpggZkXAGGOCmBUBY4wJYlYEjDEmiFkRMMaYIGZFwBhjgpgVAWOMCWJWBIwxJohZETDGmCBmRcAYY4KYFQFjjAliVgSMMSaIWREwxpggZkXAGGOCmBUBY4wJYlYEjDEmiPm8CIjIFSKyTkTiReQJX8djjDHBxKdFQERCgf8CVwJn49yP+GxfxmSMMcHE10cCHYB4Vd2kqunA50BPH8dkjDFBw9dFoDaQ6PF6m9tmjDGmGPi6COSLiAwUkTgRidu9e7evwzHGmIDh6yKQBNT1eF3HbTuGqo5R1VhVja1atWqxBWeMMYHO10VgCdBERBqISCmgDzDNxzEZY0zQCPPlD1fVTBG5H5gJhAJjVXW1L2Myxphg4tMiAKCq3wLf+joOY4wJRr7uDjLGGONDVgSMMSaIWREwxpggJqrq6xgKRER2A1s8mqoAe3wUTnEI9Pwg8HO0/PxTIOVVT1VPOr/e74rA8UQkTlVjfR1HUQn0/CDwc7T8/FOg5nU86w4yxpggZkXAGGOCWCAUgTG+DqCIBXp+EPg5Wn7+KVDzOobfjwkYY4wpvEA4EjDGGFNIVgRMsRAR8XUMxhzP/i79pAiISDMR8YtYC0NEbhGR1u7zQP2jDNj3L1gE8v/BYFai31QR6Soii4C7KeGxFoaIXCYivwDDgbYAGmCDNCJytYhMB4aJyPm+jsfbRORaEXlHRCr7OpaiICI9RORfvo7D20TkChGZivN3GfDnAuTF51cRPZ77TTgMeBa4GXhcVb/yXO7PH5RufpHAOKAa8CLOfZWj3OWhqprluwi9R0TaA88BQ4HyQD8RaaKqH4lIiKpm+zTAM+C+j9cBLwHlgDki8rU/5+RJRMKAh4HBQIyI/Kyqy/z579N9zyKAd4HGwKvApUB/EdmsqoFydnCBlLhv1+rIALKBSTkFQEQuEJFw30Z35tz8jgKfqurFqjoTWADc7i73y/9gp3AZ8It7ufCpwA7gnyJSQVWz/bnry/0isgnoDDwA3IZzZ7yAoKqZwDrgLOBfwHtuu9/+fbr/91Jx/hYvUtVpwFc4sySDsgBACSoCIvJPEXlfRAa6Te8CNUXkfyKyEngM+BC4y13frz5APPIbAKCqU932UCABWC0idfPaR0l3fI7AbOAaEankFr4M4ADwOPhf15eI9BORrh5Nq1R1r6pOxsntevcOeX7Jff9eEZGb3KYZqpqqqsOBaiJyi7ueX30ZOz4vVf1aVbPc15OBs0RkmIh09m2kvlEiioCI3AHcgvOG3CoizwBpwBSgFNAL6OEuv15EYvzpA+S4/G4TkadEpCHkfrNKAVoD+30W5Bk6SY5PA5tx7hr3iTv20RB4BagoImV8FGqBiUglEZmEE/sbbuEG8DyaeRu4BjjnuG1L/JcVcTwE9AbigOfd97OSx2r/Al4DcI/US7xT5SUi1d1VduF0B10G/AXcISJBdxPzElEEgC7Af1T1e5x+yAjgHlWdAgxU1T/dD/0VOB+UfvFH6OH4/ErhdB8AoKorgVSceyz7q+NzjAT6quoQ4F7gBVW9EyfP0qp62HehFoyqJgM/AM2BpcD/eSxT99/5wDLgShE5K+eI1h++rLgxXgI8o6qTgIeAVkA3j3W+BtaLyCPgTGrwRawFcYq8WgNXuMvnqOpKt+trJc643FFfxesrPi0CHlPO/gC6A6hqHDAfaCAi5x/3YdEPKA0kF2ughZRHfguB2jmHn+63xZlApD98c/R0mvewqYhcoKpbVfVHd72rgY3FH2nheLwfH6vqfmAUztFoPXdcI9TjdzAceBKYizPoX+KOBI6PxyP2OOACALeQbwBaiEgzj9UHA6+KyA6gdjGEm28FyGs90FxEmh63i8txCoAVgaIkIueLSKOc1x4zKeYDISJyoft6FbAdqOVud4OILMfpThjsDu6UOAXM7y+gprue4nxoHC7p3xwLkWMNd7sLRWQu0ARnvKdEOkl+Od/0U91/lwDf4cwKQlWz3GJQHRgJ/Ay0UdUXPbcvQUp7vvB4/+KBciLS0n09F6iAM/MJEWkDvI/T3ddOVccVT7j5VtC8yotIKRG5XURWAPWBJ/154LuwiqUIiEg7EfkB5z9IBY/2nJ+/AVgN9BZnCto2oDrQwF2+Hhikqn1VdWdxxFwQhcyvBs4fXo5HVHVsMYVcYF54DzcD96rqdSVxJkYe+YmceJLUSKCxiLQQkaoi0gDn5iNDVLWHqm4vvsjzR0Q6ishk4L8icnnOuIY4U0EBFgOZwOUiEqaqa3C+7efMod+L8/71UtW/ijv+UzmDvNqrajqQiPPFsq+q7vJFDr5WpEVARMJF5D2cq/GNwOnyuNhdFupRrQ8Cv+CMBbwuzuyDSrh39XH77X4rylgLwwv57c3Zl/sHWeJ48T3cqqqrizn808pHfup+0y8tImXByQX4Gqcf+RegkntEsNUnSZyGiFyM0431Fc60z9uASuKcq5EJoKrxOF0njYAn3E3TcO/ip6qJ7thVieGlvOa44zlBq6iPBCKAecAFqjod581q7lbkLAAReR6YgDN18FmcD45f3Ncl7ZDzeIGeHwR+jvnJ7zngU5zuSETkZpzB7teBlqr6u08iz79WwBJV/RQYD4QDh3IKuIi8KCIf4gx6jwA6iMhSYB9OUSypziSvH3wUc4nj9TOGRaQjsE9V1+P0cX/qsTgUyFLVTHcgpyVOH/ETqrrR3f4uoIyqHvR2bN4Q6PlB4OdYiPyaAY/m5IdzXsfFqppQrIHn03H5gVPkhorIXzjFay0wSkRm4nSHNAT+T1U3u9vfAoS5A+ElRqDm5XOq6pUHUBGYgdMt8AzOhwCAACHu88bATpzDZ3DvZ+A+D/FWLEXxCPT8giFHL+QX6uscCphfWY9lHYCxwA3u6/44A72tS/r7F6h5lZSHN7uDyuAcOg5xn18IuadqZ7uDa5vddS7KWQbO4KKW/GuuBHp+EPg5nml+JX3myPH5XZCzQFUXA1Vx+8JxBsAr4k63LuHvX6DmVSKcUREQkb4icpGIlFfVJJzBtS9xTgg6V0RypniK+0ZEuJum5rTDMdO5SpRAzw8CP0fLLze/CJxrVN3rbtoFqOyuV+LyC9S8SqICFwFx1BSR2Tgnb90KjBaRKupcZ+QI8BPO4OCl4HybcmdaHHZ/Zsecdm8l4i2Bnh8Efo6W3zH5dQFQ1TRgGlBWRObhXKH3fi1B0yIDNa8SryB9R7h9okBTYHxOG/AO8NVx6z6Ec5nkCkCUR3upourbOtNHoOcXDDlafifNryLOpTrAOamqoa/zCJa8/OGRryMBcU6Nfxl4WUQuwpktkQW5F0B7ADjPXZbjfaAs8COQkHP4piVwPnyg5weBn6Pld9r8NotIbVU9qqqbijn8UwrUvPzJaYuA+8tfinMIFg8Mw7mA2yUi0gFy+92Guo8cV+P00y3HmUtdYs4y9BTo+UHg52j5nTa/ZTj5JRVf1KcXqHn5m/ycJ5ANvKGqnwCISFucSwH8HzAaaC/OrIopwKUiUl+debmpwGWqOq9IIveeQM8PAj9Hy88/8wvUvPxKfrqDlgJfyt/XUJ8PxKjqR0CoiAxxq3UdnJNsNoNz0xQ/eZMCPT8I/BwtP//ML1Dz8iunLQKqekRV0/TvOdJdgd3u8ztxTrGfDnwG/A4l7/K5eQn0/CDwc7T8/DO/QM3L3+T7shFutVacK0NOc5sPAk/h3E0pIadvTlVL3LS60wn0/CDwc7T8/DO/QM3LXxTkPIFsnAs07QFauRX6WSBbVX8NgMGZQM8PAj9Hy88/BWpefkEKUljFuYDTAvfxP1X9sKgC84VAzw8CP0fLzz8Fal7+oKBFoA5wO/CmOmfqBZRAzw8CP0fLzz8Fal7+oEBFwBhjTGDx6Y3mjTHG+JYVAWOMCWJWBIwxJohZETDGmCBmRcAYY4KYFQFj8iAiWSKyTERWi8hyEXnYvahZXtvUF+em5saUeFYEjMnbUVVto6otcK5tcyXw3Gm2qQ9YETB+wc4TMCYPInJIVct6vG4ILAGqAPWAT3Bufg7ObQ0XiMhCoDmQAIwDRgCvABfj3MP4v6r6XrElYUwerAgYk4fji4Dbth/nDlgHca5vkyoiTYDPVDVWRC4GHlHV7u76A4FqqvqiODdGnw/0UtWEYk3GmJPI91VEjTEnCAdGikgbnFsiNj3FepfjXBjtRvd1BaAJzpGCMT5lRcCYAnC7g7KAXThjAzuB1jjja6mn2gwYoqoziyVIYwrABoaNyScRqQq8C4x0r2tfAdju3v3qdiDnDlkHgXIem84EBotIuLufpiJSBmNKADsSMCZvpUVkGU7XTybOQPCb7rJRwGQR6Qt8Dxx221cAWSKyHPgIeBtnxtDv7p2xdgPXFlcCxuTFBoaNMSaIWXeQMcYEMSsCxhgTxKwIGGNMELMiYIwxQcyKgDHGBDErAsYYE8SsCBhjTBCzImCMMUHs/wFxfETHCG+mvQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+      "cell_type": "code",
+      "metadata": {
+        "id": "FSoRBTSxv3Fb",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 450
+        },
+        "outputId": "59be6b72-5dc1-4646-c1ff-16dc03bf2c71"
+      },
+      "source": [
+        "quandl.ApiConfig.api_key = 'zZzhwTNJ1Z8SxApaAd8K'\n",
+        "\n",
+        "df = quandl.get(\"WIKI/AMZN\")\n",
+        "df = df[['Adj. Close']]\n",
+        "df"
+      ],
+      "execution_count": 60,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Adj. Close</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>Date</th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>1997-05-16</th>\n",
+              "      <td>1.729167</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1997-05-19</th>\n",
+              "      <td>1.708333</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1997-05-20</th>\n",
+              "      <td>1.635833</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1997-05-21</th>\n",
+              "      <td>1.427500</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1997-05-22</th>\n",
+              "      <td>1.395833</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>...</th>\n",
+              "      <td>...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2018-03-21</th>\n",
+              "      <td>1581.860000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2018-03-22</th>\n",
+              "      <td>1544.100000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2018-03-23</th>\n",
+              "      <td>1495.560000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2018-03-26</th>\n",
+              "      <td>1555.860000</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2018-03-27</th>\n",
+              "      <td>1497.050000</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>5248 rows × 1 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "             Adj. Close\n",
+              "Date                   \n",
+              "1997-05-16     1.729167\n",
+              "1997-05-19     1.708333\n",
+              "1997-05-20     1.635833\n",
+              "1997-05-21     1.427500\n",
+              "1997-05-22     1.395833\n",
+              "...                 ...\n",
+              "2018-03-21  1581.860000\n",
+              "2018-03-22  1544.100000\n",
+              "2018-03-23  1495.560000\n",
+              "2018-03-26  1555.860000\n",
+              "2018-03-27  1497.050000\n",
+              "\n",
+              "[5248 rows x 1 columns]"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 60
+        }
       ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "yEjrFEi5v3Fg",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 269
+        },
+        "outputId": "21f6e347-0978-4589-d2d0-cd5c89852073"
+      },
+      "source": [
+        "df['Adj. Close'].plot(color='g')\n",
+        "plt.legend(loc='upper left')\n",
+        "plt.show()"
+      ],
+      "execution_count": 61,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAD8CAYAAACb4nSYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3wVVfr48c+TQBIwBAKEIsWAgnRQAuJ+pSiKWMH6g6+K7sqXFbHrylpWdMXVXdfGrmIDEUsUXQXWZUEEFVGpSscSECTUhF7S8/z+mMnl3jRSbkvu83698srMmTMz5yTw5NwzZ84RVcUYY0xkiAp1AYwxxgSPBX1jjIkgFvSNMSaCWNA3xpgIYkHfGGMiiAV9Y4yJIHVCXYDyNG3aVJOTk0NdDGOMqVFWrlyZqapJpR0L66CfnJzMihUrQl0MY4ypUURka1nHrHvHGGMiiAV9Y4yJIBb0jTEmgpywT19EpgKXAntUtZtX+u3AOKAA+I+q3u+mPwDc7Kbfoarz3PShwAtANPC6qj5VlQLn5eWRnp5OdnZ2VU43pYiLi6N169bUrVs31EUxxgRYRR7kTgP+CUwvShCRc4FhQE9VzRGRZm56F2AE0BU4GfhMRDq6p70IXACkA8tFZLaqbqhsgdPT02nQoAHJycmISGVPN8WoKnv37iU9PZ127dqFujjGmAA7YfeOqi4C9hVLHgs8pao5bp49bvow4D1VzVHVX4A0oK/7laaqm1U1F3jPzVtp2dnZNGnSxAK+n4gITZo0sU9OxoQJVeXXg78G7PpV7dPvCPQXkaUi8qWI9HHTWwHbvPKlu2llpZcgImNEZIWIrMjIyCj15hbw/ct+nsaEjynfT+GU509h2fZlAbl+VYN+HaAx0A/4AzBD/BQ5VPVVVU1R1ZSkpFLfLQgLM2fORET44YcfyswzaNAgz3sGF198MQcOHDjhdf/+97/TqVMnevXqRZ8+fZg+fXqJaxljaq/Fvy4G4P759wfk+lUN+unAR+pYBhQCTYHtQBuvfK3dtLLSa6zU1FTOOeccUlNTK5R/zpw5NGrUqNw8L7/8MvPnz2fZsmWsWrWKBQsWYIvcGBNZ6kQ5j1q/3PplQK5f1aA/EzgXwH1QGwNkArOBESISKyLtgA7AMmA50EFE2olIDM7D3tnVLXyoHDlyhMWLFzNlyhTee+89T3pWVhYjRoygc+fOXHHFFWRlZXmOJScnk5mZWe51//KXvzB58mQSEhIASEhI4MYbbyyRLzU1le7du9OtWzfGjx8PQEFBATfddBPdunWje/fuPPfccwBs2rSJoUOH0rt3b/r371/uJxNjTOgJge1urciQzVRgENBURNKBCcBUYKqIrANygRvVaZKuF5EZwAYgHxinqgXudW4D5uEM2ZyqquurW/i75t7Fql2rqnsZH71a9OL5oc+Xm2fWrFkMHTqUjh070qRJE1auXEnv3r2ZPHky9evXZ+PGjaxZs4Yzzzyzwvc9dOgQhw8fpn379uXm27FjB+PHj2flypUkJiYyZMgQZs6cSZs2bdi+fTvr1q0D8HQljRkzhpdffpkOHTqwdOlSbr31VhYuXFjhchljgitKAvv61AmDvqqOLOPQ9WXkfwJ4opT0OcCcSpUuTKWmpnLnnXcCMGLECFJTU+nduzeLFi3ijjvuAKBHjx706NHD7/devnw5gwYNouh5x3XXXceiRYv405/+xObNm7n99tu55JJLGDJkCEeOHOGbb77hmmuu8Zyfk5Pj9zIZY/wn5EE/nJ2oRR4I+/btY+HChaxduxYRoaCgABHh6aefrtZ1ExISiI+PZ/PmzSds7ZcmMTGR1atXM2/ePF5++WVmzJjB888/T6NGjVi1yr+fhowxgRNXJy6g17dpGCrpww8/5IYbbmDr1q1s2bKFbdu20a5dO7766isGDBjAu+++C8C6detYs2ZNpa79wAMPMG7cOA4dOgQ4zw6KRu8U6du3L19++SWZmZkUFBSQmprKwIEDyczMpLCwkKuuuoqJEyfy3XffkZCQQLt27fjggw8AZ/zv6tWr/fBTMMYESqCHUFvQr6TU1FSuuOIKn7SrrrqK1NRUxo4dy5EjR+jcuTOPPPIIvXv39slX9Mu8+OKL2bFjR4lrjx07lnPPPZc+ffrQrVs3+vfvT1SU76+oZcuWPPXUU5x77rn07NmT3r17M2zYMLZv386gQYPo1asX119/PU8++SQA77zzDlOmTKFnz5507dqVWbNm+fPHYYzxs+eWPBfQ60s4DwlMSUnR4mPTN27cSOfOnUNUoqopKCigWbNm7Nq1K2znt6mJP1djaiN57HhLXydULT6LyEpVTSntmLX0g6Br166MHj06bAO+MSZy1OgHuTWFjY03xoQLa+kbY0yYyC/M92xfdNpFAblHjQz64fwcoiayn6cx4eFo7lEAnhnyDHOuC8xrTTUu6MfFxbF3714LVH5SNJ9+XFxgxwYbY07sYM5BABrGNgzYPWpcn37r1q1JT0+nrGmXTeUVrZxljAmt2T86U5IdyD7xjLxVVeOCft26dW2FJ2NMrXT7f28HYPXuwL1EWeO6d4wxprYb0W1EwK5tQd8YY8LM6U1OD9i1Txj0RWSqiOxxp1EufuxeEVERaerui4hMEpE0EVkjImd65b1RRH52v0pOEm+MMRHMe3BK3ejAvchZkZb+NGBo8UQRaQMMAbxX8L0IZ+GUDsAYYLKbtzHOPPxn4SySPkFEEqtTcGOMqU28x+gXrZ4VCCcM+qq6CNhXyqHngPsB77GTw4Dp7jKKS4BGItISuBCYr6r7VHU/MJ9S/pAYY0ykys7P9mzXjQptS78EERkGbFfV4o+YWwHbvPbT3bSy0o0xxuAb9APZ0q/0lUWkPvAgTteO34nIGJyuIdq2bRuIWxhjTNjJKTi+ql2o+/SLOxVoB6wWkS1Aa+A7EWkBbAfaeOVt7aaVlV6Cqr6qqimqmlK0JKAxxtR2wWrpVzroq+paVW2mqsmqmozTVXOmqu4CZgOj3FE8/YCDqroTZ0H0ISKS6D7AHeKmGWOMIYz69EUkFfgWOF1E0kXk5nKyzwE2A2nAa8CtAKq6D3gcWO5+/dlNM8YYA+QW5Hq2A7k4+gk/Q6jqyBMcT/baVmBcGfmmAlMrWT5jjIkIOfnH+/QDuU6uvZFrjDFhwLulH0gW9I0xJgx4j94JJAv6xhgTBopa+gtHLQzofSzoG2NMGCjq029Sv0lA72NB3xhjwsDX274GIDY6NqD3saBvjDFh4LklzwGBfTELLOgbY0xYOSnmpIBe34K+McaEgfPbn0+juEa0iG8R0PtY0DfGmDAQJVEBXTHLc5+A38EYY8wJZeVlUa9uvYDfx4K+McaEgaz8LOrXrR/w+1jQN8aYMJCVl0W9OtbSN8aYiHAs75i19I0xJlKETdAXkakiskdE1nmlPS0iP4jIGhH5WEQaeR17QETSRORHEbnQK32om5YmIn/0f1WMMabmCqc+/WnA0GJp84FuqtoD+Al4AEBEugAjgK7uOS+JSLSIRAMvAhcBXYCRbl5jjIl4qsqxvGPh0aevqouAfcXSPlXVfHd3Cc6atwDDgPdUNUdVf8FZQauv+5WmqptVNRd4z81rjDER7WD2QZZtX0Z+YT4NYhsE/H7+6NP/HfBfd7sVsM3rWLqbVlZ6CSIyRkRWiMiKjIwMPxTPGGPC17UfXku/Kf0AaBAT5kFfRB4C8oF3/FMcUNVXVTVFVVOSkpL8dVljjAlLn2761LO9YueKgN+vytO5ichNwKXAYHdtXIDtQBuvbK3dNMpJN8YYAxzNPRrwe1SppS8iQ4H7gctV9ZjXodnACBGJFZF2QAdgGbAc6CAi7UQkBudh7+zqFd0YY2qXW/vcGvB7nLClLyKpwCCgqYikAxNwRuvEAvPdVduXqOotqrpeRGYAG3C6fcapaoF7nduAeUA0MFVV1wegPsYYUyM1rd+UQcmDAn6fEwZ9VR1ZSvKUcvI/ATxRSvocYE6lSmeMMRHi+u7XB+U+9kauMcaEgeio6KDcx4K+McaEyIaMDZ7ta7pcE5R7WtA3xpgQWbB5gWf7rNZnBeWeFvSNMSZEXln5CgDb7t52gpz+Y0HfGGNCZH2GM4gxITYhaPe0oG+MMSEWHxMftHtZ0DfGmBDp2KQj4CyKHixVnobBGGNM9TQ7qRmtGpQ692TAWEvfGGNCyJ3VIGgs6BtjTJAczD7Ioq2LPPvH56oMHgv6xhgTJFd/cDUDpw3kcM5hABRFsJa+McbUSl//+jXgrIdbxLp3jDGmlioK9rkFuUCYdu+IyFQR2SMi67zSGovIfBH52f2e6KaLiEwSkTQRWSMiZ3qdc6Ob/2cRuTEw1THGmPDnCfph2r0zDRhaLO2PwAJV7QAscPcBLsJZOKUDMAaYDM4fCZx5+M/CWSR9QtEfCmOMqe3eXvM28tjx4J5bkEuhFrIkfQmHcw8HtSwnDPqqugjYVyx5GPCmu/0mMNwrfbo6lgCNRKQlcCEwX1X3qep+YD4l/5AYY0ytdMPHN/jsbz2wlf+b/X8ALElfEtSyVPXlrOaqutPd3gU0d7dbAd4zB6W7aWWllyAiY3A+JdC2bdsqFs8YY8LX0HdC1+at9oNcd1F0vz2NUNVXVTVFVVOSkpL8dVljjDFUPejvdrttcL/vcdO3A2288rV208pKN8aYWq2gsCDURfBR1aA/GygagXMjMMsrfZQ7iqcfcNDtBpoHDBGRRPcB7hA3zRhjarWi6ZPDxQn79EUkFRgENBWRdJxROE8BM0TkZmArcK2bfQ5wMZAGHAN+C6Cq+0TkcWC5m+/Pqlr84bAxxtQ6PV/uWe7xBaMWlHvc304Y9FV1ZBmHBpeSV4FxZVxnKjC1UqUzxphaIj4mniO5R0qkn9fuvKCWw97INcaYIPj3yH9z7MFjrB27NqTlsKBvjDFBMCh5EPXq1qNbs27oBOXGnjcGvWsHbBEVY4wJmLyCPADGpowtcWza8GlBLo3DWvrGGBMgc9PmAseXRQwHFvSNMSZALn/vciC4C5+fiAV9Y4wJgEIt9Gx3aNwhhCXxZUHfGGMCwHt45sDkgSEsiS8L+sYYEwBFSyLGRMeEuCS+LOgbY0wAFM2TP23YtNAWpBgL+sYY42erd61m0LRBADSIbRDawhRj4/SNMaYa9mftJ7Ge70KAvV7p5dluEBNeQd9a+sYYU0Vf//o1jf/WmKSnj6/98faat33ytGnYpvhpIWVB3xhjquify/8JQOaxTHYf2Q34Lo34/tXv0z6xfUjKVpZqBX0RuVtE1ovIOhFJFZE4EWknIktFJE1E3heRGDdvrLuf5h5P9kcFjDEmVDo16eTZzi/M9zk2NmUs13a9tvgpIVfloC8irYA7gBRV7QZEAyOAvwLPqeppwH7gZveUm4H9bvpzbj5jjKmxikboAOQV5rFm9xrPfpuE8OrWKVLd7p06QD0RqQPUB3YC5wEfusffBIa728Pcfdzjg0VEqnl/Y4wJmQPZBzzbeQV5bNq3ybPfJalLKIp0QlUO+qq6Hfg78CtOsD8IrAQOqGrR55x0oJW73QrY5p6b7+ZvUtX7G2NMqHkH/fzCfFbvXg3ATb1u4rLTLwtVscpVne6dRJzWezvgZOAkYGh1CyQiY0RkhYisyMjIqO7ljDEmIOamzeVfG//l2e/yUhcyjjox66WLXyJKwnOcTHVKdT7wi6pmqGoe8BHwP0Ajt7sHoDWw3d3eDrQBcI83BPYWv6iqvqqqKaqakpSUVPywMcaEnKpy//z7S6S/tMIJ9vXq1gtBqSqmOkH/V6CfiNR3++YHAxuAz4Gr3Tw3ArPc7dnuPu7xhe6ausYYU6MMnDaQtXtKX/bQe3bNcFSdPv2lOA9kvwPWutd6FRgP3CMiaTh99lPcU6YATdz0e4A/VqPcxhgTMl/9+lWoi1Bl1ZqGQVUnABOKJW8G+paSNxu4pjr3M8aYULss1fcB7dLRSznr9bNCVJrKs7l3jDGmEj756RMAGsU1Yv/4/SWOPzrw0SCXqHIs6BtjTAWt3X28H79FfIsSx58a/BTjzxkfzCJVWniOKTLGmDCz+NfF9Hi5h2f/m999UyJPuAd8sKBvjDEnlJ2fTf83+nv2h3ca7jOdcnKj5BCUqmqse8cYY05gX9Y+n/3io81X/X4Vh3IOBbNIVWYtfWOM8XIk9whfbvnSJy07P9tn/+QGJ/vsN4xrGHbz5pfFgr4xxngZPXs0g94cxLaD2zxp3nPsAHRo3CHYxfIb694xxhhXlxe7sDFzIwD7s/d7Wu83z3ZmiJ8+fDqtEloxKHlQqIpYbRb0jTEGeG/de56AD1BQWODZXrVrFeB085zX7rygl82frHvHGGOAhxc+7LOfV5hXIk+dqJrfTragb4wxwKb9m3z2j+Ud82wPOXUIAIPbDw5qmQLBgr4xxpTCO+j3PbkvgtC2YdsQlsg/LOgbYwyUeDh7ybuX8Mv+X1BVJn41EaV2zARfraAvIo1E5EMR+UFENorI2SLSWETmi8jP7vdEN6+IyCQRSRORNSJypn+qYIwx1ffFli8A2HTH8W6eV1a+4tPirw2q29J/AZirqp2AnsBGnHnyF6hqB2ABx+fNvwjo4H6NASZX897GGON39evW99kvPka/pqvOGrkNgQG4i6Soaq6qHsBZN/dNN9ubwHB3exgwXR1LcJZVbFnlkhtjjB/F1Ynj3rPvpV4d36UO92aVWNW1RqtOS78dkAG8ISLfi8jrInIS0FxVd7p5dgHN3e1WwDav89PdNGOMCan8wnyy87NJiE0gITbBk562L42eL/cMYcn8rzpBvw5wJjBZVc8AjlJsCUR3DdxKPf0QkTEiskJEVmRkZFSjeMYYUzE5+TkA1KtTD2fJb8fP+372bH/8/z4OerkCoTpBPx1Id9fKBWe93DOB3UXdNu73Pe7x7YD3jESt3TQfqvqqqqaoakpSUlI1imeMMRWTlZ8FOF083tbsXuPZHt5pOLVBdRZG3wVsE5HT3aTBwAZgNnCjm3YjMMvdng2Mckfx9AMOenUDGWNMyCz+dTFQ+/rvS1Pdd4pvB94RkRicBdF/i/OHZIaI3AxsBa51884BLgbSgGNuXmOMCbknFz8JwLfp3wJwVquzWLp9qed4bWnlQzWDvqquAlJKOVTiXWW3f39cde5njDH+pqrsPOx0OiQ3TAZgwagFxD8Z78lTfBhnTWZv5BpjItoz3z7DtkPOwMInBj8BQN3ouj557jv7vqCXK1Bq/pRxxhhTBc9++yz3fnqvT1qTek0AqBt1POivHbuWbs26BbVsgWQtfWNMRCoe8AHPcE3vYZuN4hoFrUzBYEHfGGOAlJNLezwJzU5qFuSSBJYFfWNMROrftr/Pfm5Bbqn5YqJjglGcoLGgb4yJSIVa6LNf9FZubWdB3xgTkb7e9rXP/v92/98QlSS4bPSOMSbiFG/lp9+dTssGkTHprwV9Y0zEKb4wSkJsAlHi2/Hx7pXv+oziqS0s6BtjIs6Owzt89utElQyFI7uPDFZxgsqCvjEm4mw76LyB2/yk5gw7fViJ2TVrM3uQa4yJCDsO7+DhhQ+TX5jPgwsfBOCdK9/hlcteqZXdOGWxlr4xJiI8sOABpq+ezhNfPeFJaxDbIIQlCg1r6RtjIoL3fDqRrNpBX0Si3TVyP3H324nIUhFJE5H33bn2EZFYdz/NPZ5c3XsbY0xFFZ9Dp2OTjvQ5uU+IShM6/mjp3wls9Nr/K/Ccqp4G7AdudtNvBva76c+5+Ywxpkz5hfn8mPkjq3atqva1OjTuAMD57c9n2ehl/HjbjxHVl1+kWkFfRFoDlwCvu/sCnIezXi7Am0DRkjPD3H3c44MlEn/ixpgKq/t4XTq92IkzXjmDXw/+Wq1rFb2Q9dYVb9GnVeS18ItUt6X/PHA/UPR6WxPggKrmu/vpQCt3uxWwDcA9ftDN70NExojIChFZkZGRUc3iGWNqqt/O8l1R9bPNn1XpOgWFBfyY+aPnj4YQ2W3NKo/eEZFLgT2qulJEBvmrQKr6KvAqQEpKivrrusaYmmXaqmk++0dyj7B5/2baJ7av8DXyC/Op+7jvA9zaNj9+ZVWnpf8/wOUisgV4D6db5wWgkYgU/TFpDWx3t7cDbQDc4w2B2r/0vDGm0pwltR1PDnYWLb9z7p2cOulU9mXtq/B1/rq45KPD2Dqx1S9gDVbloK+qD6hqa1VNBkYAC1X1OuBz4Go3243ALHd7truPe3yhev9mjTEGp+896s9OaLq267UMPGWgz/HMY5me7YLCAjZmbKQsD3/+sM/+pR0v9WNJa6ZAjNMfD9wjImk4ffZT3PQpQBM3/R7gjwG4tzGmhlu9a7Vn+9IOl5ZYpHz3kd2e7TqP16HLS13YcmBLqdfq1LQTAKN6juLZIc/y75H/9n+Baxi/vJGrql8AX7jbm4G+peTJBq7xx/2MMbXXkdwjnu3hnYazcudKn+M/7f2J/qf4rno1cdFEWsa35PHzHvdJ79m8J4VayJvD38Q47I1cY0xY8Z72uEFsgxJr147+92jW7VnHW6vf8qRN+X4KE7+aSEFhAbuP7OaK968g42gGOQU5xEZHdh9+cTb3jjEmrCxJXwLAN7/7BoD4mHh0gqKqnr7+7pO7l3ru+W+dz897f2b74e1c0P4CcvJzIv7BbXEW9I0xYWPTvk08+uWjALRt2NbnWEXe5fxiyxee7YLCAmvpl8KCvjEmpHILcomdGMuzQ57lnk/v8aRXZPnC+nXrl1gFq8gdc+/wWxlrE+vTN8aE1F+++guAT8AHSixfCLD6ltU++8tGL/Nsp9+dHoDS1T7W0jfGhFRpwb20NIAezXv47Hdt1pWd9+6kSb0mJYZ2FhneaXip6ZHKWvrGmIAr1ELunXcvm/Zt8knfvH8zE76YQEJsgift4f4Pc/iBw2Veq+gFq7nXzQWgRXwLT8BvEd8CgI3jjr+w1aVpF/9UopaQcH4pNiUlRVesWBHqYhhjqmnB5gWc/9b5nv2LTruIBrENmLF+BgDtE9uzef9mAPbct4ekk5LKvFZeQR4/ZP5A9+YlR/Ck7Usj42gGZ7c5m5z8HF777jXG9RkXcVMoi8hKVU0p9ZgFfWOMPxVqIev2rKN7s+6ICHkFecRMjCn3nMcGPcZD/R/iUM4hEuslBqmktVd5Qd/69I0xfhU3MY68wjwAch/OPWHA79G8Bw+c8wDRUdEW8IPA+vSNMWX6aONHzEubV+H8BYUFnoAPcN+n95Wbv2tSV1bfsrrMh7DG/6ylb4wpVb/X+7F0+1IAdMKJu4EPZB8g8a++LfVJyyZ5tmePmM1lp1/Gvqx97M/az/jPxvPKpa/4t9DmhKylb4wpVVHAB8qcw37w9ME0/3tzfj34q0/A3z9+v0++rIeyuOz0ywBoXK8xpzY+lQ+v/ZAm9UssnmcCrMpBX0TaiMjnIrJBRNaLyJ1uemMRmS8iP7vfE910EZFJIpImImtE5Ex/VcIY4x9p+9KQx4RbPrnFJ/0fS/9RIq+qsvCXhew5uodTnj/Fkz76jNElVqeKqxMXmAKbSqtOSz8fuFdVuwD9gHEi0gVnnvwFqtoBWMDxefMvAjq4X2OAydW4tzEmADr8owMAr6z07XYpmg/HW9FC48U9eb6z0tW8651nAalXpfqxhKa6qtynr6o7gZ3u9mER2Yiz+PkwYJCb7U2cefbHu+nT3dWylohIIxFp6V7HGBMiu47souUzLXl04KPl5juWd4z6desDsPXAVga9Ocjn+LRh02iV0Iqm9ZsCMOTUIRV6FmCCyy8PckUkGTgDWAo09wrku4Dm7nYrYJvXaelumk/QF5ExOJ8EaNvWd5Y9Y0z1ZR7L5Jf9v9AivgVtGrah3+v9gNJb838e9Gce+eIRAE76y0me9L+e/1fPalV/GvAnbu1zq+dtWBPeqv0gV0TigX8Bd6nqIe9jbqu+Un/qVfVVVU1R1ZSkpLLfyjPGVN47a94h6ekk+r7el7bPt+XzXz5n68GtPnlu63ObZ/vB/g/Sq0WvEtcZ/9l4z3ZMdIwF/BqkWkFfROriBPx3VPUjN3m3iLR0j7cE9rjp24E2Xqe3dtOMMQGWW5CLPCZc//H1PunnTT+vRN4XLnrBsx0dFc1H135UIo+32/ve7p9CmqCozugdwVnsfKOqPut1aDZwo7t9IzDLK32UO4qnH3DQ+vONCbwD2QeInVj+QiJrblnjrE41QYmSKP5x0T9Y/n/LAWiX2I4td27x5L2kwyW0TmjNgfEH0AlKw7iGgSy+8bMqz70jIucAXwFrgaLH+A/i9OvPANoCW4FrVXWf+0fin8BQ4BjwW1Utd2Idm3vHmOopekjrrfCRQl5e8TK3zrnVk1aRB65ZeVmIiA2/rAECMveOqi4Gypq6bnAp+RUYV9X7GWPK9tXWrxgwbQBZD2X5BOXPNn/mk++li19CRBjbZyyjzxzNXXPv4onBT1ToHvXq1vNrmU1o2Bu5xtQgBYUF/GbKb7jonYtYs3sN4LwkNWDaAAAe+OwBn/w3fHwDAO9e+S46QRnbZ6znWN3ourx4yYslXqQytZsFfWNqkPgn4/k2/Vvmps2l58s92Xl4J1F/Pv7f+Pmlz7Pwl4WoKiP/NRKAxLhERnYfGaoimzBjE64ZU0PMWD+D7Pxsn7STnz25RL7B0317V28+4+aAlsvULNbSN6aGuP2/ztDIh/o/VGKB8H3372PCwAmlnveH//lDwMtmag4L+n7y18V/5c1Vb5abZ9LSSXR50dbrrA12HdlV5syTgXJ156sB5w3YHs17sOmOTdSvW58ZV88gsV4ijw56lEN/PP5+5CMDHkEnKM1OahbUcprwZkG/in7a+xP7s5zpY7cd3MYfF/yRm2bdVGZ+VeXOuXeyMXMjU76bEqRSmkB4aflLtHymJU3+1oSHFjyEPCZ8sP4Dv98nJz+Hqd9PpVALeX7J87y04iUAYus4Y+7bJ7bn6INHuabrNZ5zGsQ24KfbfmLe9fN47NzH/F4mU/PZGrlVJI8JHZt05MfbfkQeOz5ytfh454PZB0l5LYUezXvw0cbjbzb+7fy/cd9v7ou4BZtrqq0HtvLGqjc4kH2AF5a+UGqeot+9qgR4dUQAABAOSURBVJJ5LJP5m+fzwYYPmD58OglPJdDspGbsundXub/zzzZ/xpHcI0z4YoJndE5Z9zGmLLZGrp8VFBYATmu/uJz8HE9LDODOuXeSti+NtH1pPvnu/+x+9hzdwx1n3UGbhm2KX8aEibyCPD7f8jl3z7ubDRkbys0rjwkTz53Iw58/7JOe8FQCAHuO7iHqz1EUPlJYIvCrqs8onLLk/ym/kjUwxpd171TBwZyDnu2+r/X1ORb3RBwzf5jJDR/fwJdbvuTN1WX38//927/T9vm2TFo6qcw8JnQKCguImRjDhW9f6BPwb+p1kyf4NoxtyIfXfOg5Vjzgl+auuXf57KeuTS0z4N/d724uP/1yHur/EDpBiY6KrkpVjPGw7p0qmPPzHC5595JKnycI3Zt3L/Nj+7tXvlujx1O/t+49Rv5rJO9c+Q7DOw1n5+GdrN69mis7X1kib25BLjHRMSEoZcUUaiHRf/YNsPEx8fznf//DgFMGlMj/+JePe6YgBpg1YhZntDiDjzZ+xF3z7uLWlFtpn9ie++Y7C4VPvXwqN/W6iVdXvsot/zm+StUnIz+hc1Jn2jZsS50o+yBuqqa87h0L+lXg3Ydf5Pvff88Zr5xRav4Hz3mQQcmD6NuqL3F14uj0YicGnDKADRkbWLHDt35pt6dxauNTOZZ3jCiJqhHznGTlZXH3vLtLrLZUZPrw6QxuP5jTJp3GwwMe5qGFDwHQvVl31owt+Qew6N9kWX3fqsqS9CX0adWHnPwcfjnwC1sPbGX8Z+O5tOOlPNT/IRrENqhWnY7mHiX+yXgAMv+QWaG1XFfvWs2omaNY9ftVPmUv1EKixGnJl/Zvp8gtvW9h8qW2oJypPgv6fpRXkEfMRN8W6vpb19MlqQt7ju6h+d+b+xz7YdwPnN709DKvd8FbF5SYH8V74YonBz/JaY1P4+ouV/upBv5RqIUs276Ms6ecXa3rnNb4NM/zjiGnDiExLpH3178PQKsGrdhy1xZPi1dVERHun38/T3/zdLnXTTk5hamXT2XXkV2c2+5cBGHR1kX0aN7DE8ALtZC3Vr/Fa9+9RtuGbTmv3Xl8vuVzjuYeJSE2gbfWvMXkSyZzS8ot5d6rMu779D6e+faZEum779ttQyuN31jQ96OiltojAx7hvt/cx6ebPuWqLld5jm87uI0oiSJ1XSpz0+by2ajPyroU4LSSM49lsvvobvq81qfMfAtGLeC8diXnPg+mrLwsjuUd4601b3H3vLtLHP/0+k+54NQLUFWO5h2lXp16TFw0scSKTCO6jeDJwU/S7oV2FbpvUv0kMo5lAM6CHbkFuaXmW/X7Vew5uochbw8p93oju40kdd2J1229uMPFvH3F2yTWS6xQOSvq440fc+UMp8tLJ6jPJwFj/CGsgr6IDAVeAKKB11X1qbLyhjLor9+znivevwKAO866g+u6X8eKHSs8AWXTHZton9jer/ec+v1Ubp59/JX5bs26sW7POs/+gFMG0CahDZMvmVzt7guAHzN/JD4mnhbxLTwPCFWV73Z+x+9m/47N+zcz+ozRNKnfhMW/Lmbepnk+55/T9hzqRNXh0YGPMjB5YLn3Kmqle3vj+zeY+eNMnhnyDOv3rOeDDR9w79n30i6xHQWFBUxaOoktB7ewdvdavt/1Pdd1v45WDVqRlZ/F73v/nq7NugKQX5hPtER7rp95LJMFmxewN2svTy1+im2HnFU6i/88AbokdeGr335FlETx896f+W/afzm79dm0T2zPqY1PrfoP9wQ/i9e+e43hnYZb694ERNgEfRGJBn4CLsBZI3c5MFJVSx0LF6qgn5OfQ9wTZfelz71uLheedmHA7p+dn01cnTg27dvEaf84rdQ84/qMI3Vdaom3Qn/X63c8MfgJmp/UnKN5R/lo40dsyNhA5rFMpnxf/kthfU7uw/Idy09Yvht63MC04dNqZOv03bXv8vkvn3NTr5s4q/VZ9rDU1ErhFPTPBh5V1Qvd/QcAVPXJ0vJXNejnFuSybPsysvOzyc7PJr8wn73H9rLn6B62HtxK+qF0erXoxcHsg+QX5nMo9xCb929m28FtZOVn+QTSUT1HMX31dMBpKc78fzMD1gIsT9HImIoqrxvEW4OYBhzOPQxAi/gW7Dqyiys6XcHpTU5n/Dnj+XnvzyTWS+RI7hF6Nu9pL5MZUwOEU9C/GhiqqqPd/RuAs1T1ttLyVzXol/ZAtbgoiaJhbEPqRNUhJjqGVgmtaJ/YnoQY50Wa6KhoXrrEee296GWscBkjvTFjIzN/mElOQQ4PD3iYOlF1yDyWSW5BLo98/giFWsh3O79j9e7VxETH8MyQZ9hyYAsjuo2gd8veiEiJ7paCwgKiJMqCujG1QI16I1dExgBjANq2bVulayTGJTL/hvnE1YkjNjqW6KhomtZvSlL9JGKiYyodvMMl2BfpnNSZzkmdfdKa1m8KwOuXv16haxQP7uFWR2NMYAQ76G8HvOccaO2meajqq8Cr4LT0q3KTutF1Ob/9+VUtozHG1FrBfhK3HOggIu1EJAYYAcwOchmMMSZiBbWlr6r5InIbMA9nyOZUVV0fzDIYY0wkC3qfvqrOAeYE+77GGGNslk1jjIkoFvSNMSaCWNA3xpgIEtYTrolIBrA11OUIgKZAZqgLEQSRUk+InLpaPWuGU1Q1qbQDYR30aysRWVHW23K1SaTUEyKnrlbPms+6d4wxJoJY0DfGmAhiQT80Xg11AYIkUuoJkVNXq2cNZ336xhgTQaylb4wxEcSCvjHGRBAL+sYYE0Es6AeY1PKlqESkvvu9VtcTQETqhroMwRAJv0sAEekqImUvhl1LWdD3MxE5R0Qmi8itAFoLn5SLSJSINBaRT4E/QO2sZxER6Sci7wFPi0i3UJcnUESkr4i8BowXkVLf5qwNRKSHiCwGJgJNQl2eYLOg70ciciYwGVgJXCwiz4lIrxAXy+9UtRDIBxoC7UXkfKidLUQRuQbnd/oJEAfc46bXmrqKSLSIPIkzTPFr4ExggoiUv9B0zfUw8KGqXqGq26F2/T5PxIK+f/UFlqvq68Bo4BhO8G8a2mIFRBdgN/AVcJmI1Kulrf0OwL9V9W3gOXC6eWpZXaOAX4FrVXUacBfQD6gXykL5m/sJtT1wRFWfd9MuEJFGOIs6RUTwt6BfDSJyrYjcIyK/cZO+A+JFpIWq7gIWAknAOSErpB941bOfV/JWYB3wE1AIDBWRFiEpoB951fVsN+lH4EoRuR/4FjgZeFFEavS8LG6XVUd3txBIVdWfRCRWVXcA6TiTjtVo3vV0P6FmAv1F5BIRmQncB0wiAropi1jQrwL34/AjwHg36RURuQw4CmwBBrrpXwIHcBaAr3GtiFLq+ZqIXOlu9wLqq+oinDr+A5goInVqWj2hzLpeDnwE3AkMAEap6lAgA7i6Jv6RE5FGIvIfYD5wrYjEq2qBqh4AUNUcEWkAtAN2hLKs1VFKPU8CUNVDwBvA4zjLtV4IvA70K9aoqbUs6FeBqhYApwP3quqzwGPAbTjLT+4AeolIF1XNx2kpXuGeV6NaEaXUcwJwh9ty2gEcFZE3gN/itPjXqGp+TasnlFnXu4GOqroAyMb5XQLMAnrg/JGvaU7CWaP6dne7fyl5zgLWq+oOEYkXkQ7BLKCfFK/nAK9jnwDJQKK7vwKnqzIniOULGQv6FSQio0RkoNv/B84/kkQRqaOqHwKbgAtwunSycUYGALQClotI0NcjrooT1PMjYD0wHKfb6kLgENATeBo4Q0SSg1/qqjlBXf+FU9eRbot+E3C1m+8MnN9xjeBVzwT3weWrwAycOpwlIie7+Yr+jTYCtonIb4HlOJ/qwl4F6tkKQFXX4HTn3OY+b7se6AbsDVHRg8rm3imH203RAngXp99zE06r4ffAHTgt+0mqekBEOgHvAReq6m4RmQo0B5oBI1U1LRR1qIhK1rOzm28IkON+XEZEWgL5qpoRgipUWBV/pxfgtOzH4fTpHwFuU9Ufgl+Diimnnneqaqab53+Aa3EGH7ztde5bwHXAm8BzbpAMS5Ws5wpVfcvr3HuA9jgP6+9W1Q1BLn5oqKp9lfIFRLvfOwJvF6XhDN+bitMamovzsbG+e3wGzj8egLpAUqjrEcB63uluRwFRoa5HAOv6AXCrux0PdA91PapRz38AHxXLezfOp9IEIN5NGwFcHep6BKieDYEGXul1Q12PYH/ViC6HYBKRaJyHPNEiMgfnP0MBOP2+InIbsBN4Bqd1MQJoCbwP5AHfuHnzcB74hSU/1HOJm7cw+KWvnGrWNRfnvQtU9QiwNugVqKAK1PNOYIeIDFTVL93TXsMJhguAtiLSS1XfC0HxK6ya9ZwPnCIiZ6jqDvf/aUSxPn0vIjIQ5z94IpCG8w8rDzhXRPqC54HfY8DTqjod+BQYJSLf43QNhG1QKBIp9YTIqWsF61kIPOp+FbkEuBVYhfMpZmfwSl15fqjnapx61tiRSdVlffpeRKQ/kKxuv5+IvITzHz4LuF1Ve4tIFE4//T9xunK2uQ/66qvq5lCVvTIipZ4QOXWtZD0nAfer6hYRGQbsV2fobdiLlHoGkrX0fa0EZrgfH8F5Jb2tOm8pRovI7W4rojWQp6rbAFR1V00JDq5IqSdETl0rU88CVd0CoKqzalggjJR6BowFfS+qekxVc9yP++CM2ijql/8t0FlEPgFScd6+rZEipZ4QOXWtSj3dkS81SqTUM5DsQW4p3FaE4gy5nO0mHwYexBnP+4u6EzXVZJFST4iculamnlqD+3YjpZ6BYC390hXiDLnMBHq4LYc/AYWqurg2BAdXpNQTIqeuVs/aVU+/swe5ZRBnHo5v3K83VHVKiIsUEJFST4iculo9TXks6JdBRFoDNwDPqmqtnZMjUuoJkVNXq6cpjwV9Y4yJINanb4wxEcSCvjHGRBAL+sYYE0Es6BtjTASxoG+MFxEpEJFVIrJeRFaLyL3uXC7lnZMsIv8brDIaUx0W9I3xlaWqvVS1K84r/hfhLJ1YnmTAgr6pEWzIpjFeROSIqsZ77bfHWTKwKXAK8BbOykzgrJ71jYgsAToDv+CsNjUJeAoYBMQCL6rqK0GrhDHlsKBvjJfiQd9NO4CzaPphnNf8s8VZLDxVVVNEZBBwn6pe6uYfAzRT1YkiEoszE+Q1qvpLUCtjTClswjVjKq4u8E8R6YWzUlPHMvINwZkPpmgh9YY467Ba0DchZ0HfmHK43TsFwB6cvv3dQE+c52HZZZ2Gs6DHvKAU0phKsAe5xpRBRJKAl4F/utPzNgR2uot03ICzCDc43T4NvE6dB4wVkbrudTqKyEkYEwaspW+Mr3oisgqnKycf58Hts+6xl4B/icgoYC5w1E1fAxSIyGpgGvACzoie79wFPDKA4cGqgDHlsQe5xhgTQax7xxhjIogFfWOMiSAW9I0xJoJY0DfGmAhiQd8YYyKIBX1jjIkgFvSNMSaCWNA3xpgI8v8BoKiUXdwRve0AAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "hLYyMCVov3Fj",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "forecast = 30\n",
+        "df['Prediction'] = df[['Adj. Close']]\n",
+        "\n",
+        "X = np.array(df.drop(['Prediction'], 1))\n",
+        "X = preprocessing.scale(X)\n",
+        "\n",
+        "X_forecast = X[-forecast:]\n",
+        "X = X[:-forecast]\n",
+        "\n",
+        "y = np.array(df['Prediction'])\n",
+        "y = y[forecast: ]"
+      ],
+      "execution_count": 91,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "a4fwiXttv3Fn",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 119
+        },
+        "outputId": "674d56f9-bb71-4cb4-f045-a9a5ac77fe5b"
+      },
+      "source": [
+        "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)\n",
+        "\n",
+        "clf = LinearRegression()\n",
+        "clf.fit(X_train, y_train)\n",
+        "\n",
+        "confidence = clf.score(X_test, y_test)\n",
+        "\n",
+        "forecast_predicted = clf.predict(X_forecast)\n",
+        "print(forecast_predicted)"
+      ],
+      "execution_count": 92,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[1497.89401006 1536.67148546 1548.03729721 1534.16697419 1555.03082658\n",
+            " 1570.49299999 1572.4456698  1588.61886972 1611.91294703 1601.33244814\n",
+            " 1601.83122792 1581.6677897  1588.88417812 1613.67459479 1628.56370207\n",
+            " 1636.3743813  1643.65444373 1672.33958768 1693.0336427  1682.19844774\n",
+            " 1685.19112647 1675.9796189  1664.6880935  1636.30009495 1680.42618764\n",
+            " 1675.49145145 1635.41927107 1583.90699258 1647.89937809 1585.48823063]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Ve_CIKdJv3Fr",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 295
+        },
+        "outputId": "c443792a-eff5-4d5b-9d1c-8944717b7ac6"
+      },
+      "source": [
+        "dates = pd.date_range(start=\"2018-03-28\", end=\"2018-04-26\")\n",
+        "plt.plot(dates, forecast_predicted, color='y')\n",
+        "df['Adj. Close'].plot(color='g')\n",
+        "plt.xlim(xmin=datetime.date(2017,4,26), xmax=datetime.date(2018, 4, 26))"
+      ],
+      "execution_count": 95,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(736445.0, 736810.0)"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 95
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAEFCAYAAAAFeFvqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3xUZdbA8d9JAqEkQOglVAmIGIpEYKW6goIioK4dEXUBEdv6vuuCZXUX3VexrWKvwIogoigoILCKIIiSYKRKRyBAEiBAKOnn/ePexAECJGGSycyc7+czH2aeW3JOJsyZ+9zn3kdUFWOMMcEpxNcBGGOM8R0rAsYYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPEwoq7gYi8DwwAUlT1QrftY6C1u0oN4KCqdhCRZsB6YIO7bLmq3u1u0wmYCFQG5gAPaBHGq9auXVubNWtW3LCNMSZoJSQk7FPVOoUtK3YRwPngfhWYnN+gqjfmPxeRF4BDHutvUdUOheznDWA48CNOEegHzD3bD2/WrBnx8fElCNsYY4KTiPx2umXF7g5S1cXAgdP8IAFuAKaeJaAGQDVVXe5++58MDC5uLMYYY86Nt88J9ACSVXWTR1tzEflZRL4TkR5uWyNgl8c6u9y2QonICBGJF5H41NRUL4dsjDHBy9tF4GZOPArYAzRR1Y7AQ8BHIlKtuDtV1bdVNU5V4+rUKbRbyxhjTAmU5JxAoUQkDLgW6JTfpqqZQKb7PEFEtgCtgCQg2mPzaLfNGGNMGfLmkUAf4FdVLejmEZE6IhLqPm8BxABbVXUPcFhEurrnEYYCX3gxFmOMMUVQ7CIgIlOBH4DWIrJLRO5yF93EqSeEewKrRCQRmAHcrar5J5XvAd4FNgNbKMLIIGOMMd4l/nYr6bi4OLUhosaYYJebm8HBg99Ss2Y/nA6V0xORBFWNK2yZXTFsjDF+aNu2x1i9+kp+/XUoO3Y8j2oeAKq5FOfLvRUBY4zxM3l5mSQnO9frJid/yNatf2XLlv8BYOXKS1i+vClHjqwp0r68NjrIGGNM2di//0uys1OJjZ1D5coxJCVNYNeuf1OpUgvS038CYOfO8bRpM/kse7IiYIwxfmffvi8IC6tFVFRfQkLCOO+8F0hP/4nNmx8EICSkEocP/1ikfVl3kDHG+JG8vBz27/+KWrWuIiTE+R4fEhJGgwbDAee8QMOG93D8+EYyM5PYvPmhM+7PioAxxviJvLwcNm26l5ycA9SufeLt1mrVGgAI4eFN3Oewc+cL7Nr10hn3ad1BxhjjB1RzWbv2Ovbvn0Xjxn+jdu1BJyyvWLEutWpdTXh4QyIjndGgKSnTz7pfKwLGGOMH9ux5n/37Z3HeeS/SuPFfCl0nNvb3Gy9UqtScjIxtZ92vdQcZY0w5k5LyMatXDyQnJx2AvLwstm17jOrVexAd/WCR9lG1atsirWdFwBhjSmh96nq+2viVV/epqmzYMIL9+2ezYsWFbN36KAcOfE12dgpNmow569XB+apWvbBI61l3kDHGFJOq8u7Kd7l/3v1k5GRwa+ytdGrQiQe7PnjCh/Suw7toFNmoyB/cAOnpP5Gbe5ioqL5kZe1lx45nqVbt4oIhoUVVpYpzJCBSAcg+7Xp2JGCMMcWQkZPBrZ/dyogvR9CjSQ8ubXYpU9dM5aH5D/HP7/5ZsF7C7gQav9SY2DdiOZJ1pMj737HjOUJDI2jbdgaxsbOBXA4fXk79+sMICalQ5P3kHwlUr979jOvZkYAxxhTDxMSJTF0zlXGXjuORHo+Qp3lk5WYxes5onvzuSWJqxXBL7C0s2r4IgLWpa5m/ZT7Xtrn2jPvNyTnM9u1Psm/fpzRr9g/CwqoRFlaNZs3GoZpJ06ZPFCvOiIj2tGw5gRo1egOxp13PioAxxhTDp+s/pVWtVjza41FEhBAJISwkjLcGvMW2tG0MnTmUymGVWbF7BfUj6pN2PI2lO5aetQhs2/YYSUmvUqvWAKKjf7/Aq1mzx0oUp4gQHX3vWdezImCMMUW0O3033277loe7PXxKP3/F0IrMvnk2V3x4BTfOuJEqFarQ97y+7Enfw9KdSwvWu/vLu8nNy+Wdge8AzhFAdnYqSUmv07DhSFq1eqNMc7JzAsYYUwSJexP5w3t/oEJoBYa0G1LoOpHhkcy9dS7t67fnUOYhOjfsTPcm3Vm5ZyXHs4+z/eB23ln5DnM2zwHg8OGfWLasHj//3AsRoWnTv5dlSoAdCRhjzFltTdtKjw96UD28OkvuWMIFdS447brVK1Vn/pD5jF86nts73M73O74nOy+bNSlr+Hjtx+RpHrvTd5OeeZh1624mLy+DrKwk6ta9ifDwBmWYlcOOBIwxBth/bD+zN8w+ZUKW7Nxs7v7ybgCW3rmUuIaFTtB1gqjKUfxfn/+jbtW6tKvXDoBlO5fx7sp3qVW5FgCrkxaSkbGVFi2epVatgTRp8oiXMyqaEhUBEXlfRFJEZI1H25MikiQiie7jSo9lY0Vks4hsEJErPNr7uW2bRWTMuaVijDElsy51HZ3f7czAaQO556t7+GbbNwAczTrK4I8Hs2DrAp7r+xxNazQt9r5bRLWgSoUqPL3kaQ5lHuKpPz4FwOrdCwCoVetqYmO/ICLi9CN4SlNJjwQmAv0KaX9JVTu4jzkAInIBziT0bd1tXheRUBEJBV4D+gMXADe76xpjTJmZt3kef3jvDxzNOsqg1oN4M+FN+n3Yj8S9iVw66VLmbZ7Hm1e9yd1xd5do/yESQmzdWFKPpRLXMI6h7YcCsD5lBWFhNahSpbU30yl+fCXZSFUXAweKuPogYJqqZqrqNmAz0Nl9bFbVraqaBUxz1zXGmDKRsDuBAR8NoHmN5qwYvoLPb/qclSNWkp2XTce3OrImZQ0zb5zJyLiR5/Rz8ruEHujyAFUqVKFxtcZs3L+ZatX+gIhve+W9/dPvFZFVbndRlNvWCNjpsc4ut+107acQkREiEi8i8ampqV4O2RgTjFbuWcmor0ZRq0otFg1bROPqjQHo2KAjf+74Z5pUb8KiYYsY2HrgOf+s6y+4ngGtBnBD2xsAGHT+IFrVbkvdujee877PlTdHB70BjAPU/fcF4E5v7FhV3wbeBoiLi9OzrG6MMWe0JmUNnd/pjKJ8eM2H1KhU44Tlb139FoIU654/Z9L3vL70Pe/3+/5M6D/BK/v1Bq8VAVVNzn8uIu8AX7ovk4DGHqtGu22cod0YY7wmJy+HMHcqxl/3/crtn99O9UrVWTNqDQ0iTx2WGeLjLpqy5LVMRcTzN3kNkD9yaBZwk4iEi0hzIAb4CVgBxIhIcxGpiHPyeJa34jHGBJ6Th28WxUNfP0Tjlxrzy95fuG/OfVz4+oVsPrCZd69+t9ACEGxKdCQgIlOB3kBtEdkFPAH0FpEOON1B24GRAKq6VkSmA+uAHGC0qua6+7kX+BoIBd5X1bXnlI0xJmB9vflrrv/keuJHxNOqVquCdlUlT/MIDQk9ZZtZG2bx0nJnjt0Ob3UgREIY2Wkk/+j9D+pUrVNmsZdnJSoCqnpzIc3vnWH9p4GnC2mfA8wpSQzGmOCRmZNJvynOqPRlO5edUAR6TexFelY6P4/8+ZTtZm2YRY1KNXil3yt8tekrHu/5OG3rFm3GrWARPB1fxhi/9dHqj054fsWHV7Dv2D5UlSU7lpC4N5GUoymnbLdkxxK6Ne7Gbe1vY9qfplkBKIQVAWNMuZaZk8m/f/w3F9a9kKbVm7Jg6wLmb5nPkM+GsOPQjoL1Plv/2QnbJR9JZuP+jfRo0qOsQ/YrVgSMMeXWvM3ziH0jllXJq/hbt78RUysGgMiKkXy95Wtu//z2gnXnb5l/wraLf1sMQI+mVgTOxIqAMaZcunfOvfSf0h8RYd6t8xjSbggto1oCMLLTSG6NvZXvfvsOQejdrDdb0racsP3sjbOpWbkmnRt19kX4fsNuJW2MKXd2p+/m9RWvM6zDMN686k3Cw8IBaFnTKQJdorvQr2U/Vu5ZSVhIGLF1Y/kg8QNUFREhJy+HrzZ9xVUxVxVcH2AKZ78dY0y589Hqj1CUsd3HFhQAgEubX0qrWq3o1bQXERUj+P7O7zmWfYwZ62ZwJOsI+4/vp3aV2szZNIcDxw8wqLXdjuxsrAgYY8oVVeWDxA/o3KjzCUNBAS5qcBEb7t1Q8Lpm5ZrUrFyTFlEtAGfylxqVajBm4RhiasZ45b4/gc6KgDGm3Phh5w888s0jrEtdxweDPijydvlFYFvaNhL3JrJ+33pm3jiTCqEVSivUgGFFwBhTbjz27WMs2r6IyIqR3HThTUXerlmNZgD8kvwL7//8Pt2bdLeuoCKyImCMKRdy8nL4KeknejXtxatXvkqlsEpF3jaiYgTNazTnhR9eICs3iy9u+sJrdwANdDZE1BhTLqzcs5IjWUcYFTeKC+teWOzt3xzwJtm52dzY9ka6RHcphQgDkx0JGGPKhU/XfQpAr2a9SrT95eddTuLdicTUjPFmWAHPioAxxufmbZ7Hc8ue49bYW6kfUb/E+8mfxtEUnRUBY0ypm79lPjPWzSBEQgiREMJDwxnRaQRt6rRhy4Et3PzpzbSr1463r37b16EGHSsCxphS99DXD7E1bSvVwquRq7mkZ6Yzbe00Hu/5OK+veJ0QCWHmjTOpUqGKr0MNOnZi2BhTqrYc2MLa1LX867J/sfd/95L611QSRiQQIiGMnjOabQe3Me26aTSPau7rUIOSHQkYY0rVrA3OrLGeV++2rduWnX/Zye703dSuUrtYw0GNdxX7SEBE3heRFBFZ49H2nIj8KiKrRGSmiNRw25uJyHERSXQfb3ps00lEVovIZhF5RWxQrzEBacrqKbSv177gqt58IRJCdLVoKwA+VpLuoIlAv5PaFgAXqmo7YCMw1mPZFlXt4D7u9mh/AxiOM/F8TCH7NMb4ue+2f0fCngTu6niXr0Mxp1HsIqCqi4EDJ7XNV9Uc9+VyIPpM+xCRBkA1VV2uqgpMBgYXNxZjTPm098heBk8bTO9JvYmoGMGQdkN8HZI5jdI4MXwnMNfjdXMR+VlEvhOR/Cl+GgG7PNbZ5bYVSkRGiEi8iMSnpqZ6P2JjjNd8vOZjLnz9QuZtnsc/e/+TX+7+hajKUb4Oy5yGV08Mi8ijQA4wxW3aAzRR1f0i0gn4XESKPdOzqr4NvA0QFxen3orXGOM9OXk5DJ05lKlrpnJxw4uZNHgSbeq08XVY5iy8VgREZBgwALjM7eJBVTOBTPd5gohsAVoBSZzYZRTtthlj/NRn6z9j6pqpPNrjUZ7s/aTN6OUnvNIdJCL9gIeBgap6zKO9joiEus9b4JwA3qqqe4DDItLVHRU0FPjCG7EYY8re0ayjjF86npY1W/KP3v+wAuBHiv1OichUoDdQW0R2AU/gjAYKBxa4Iz2XuyOBegL/FJFsIA+4W1XzTyrfgzPSqDLOOQTP8wjGmCLIzMkkNCTUpx+6GTkZdH63M+tS1zFp8CRCQ0J9FospvmL/5ajqzYU0v3eadT8FPj3Nsnig+PeLNSbI5Wkei7YvYmLiRD5d/ymhEsqH1354TlMp5uTlMHP9TPYc2cONbW+kXkS9QtdTVfI074QP+vFLx7MudR0zb5zJ4PNtkJ+/sdtGGONnRswewWWTL2PWhlkMiR1Czco1mfDTBHLycs6+8UnSM9MZv3Q8LV5uwQ0zbuCBeQ/Q8a2ObEvbdsq6i7Yvout7XanzXB12p+9mXeo6rvroKp5Y9ATXtbnOCoCfso47Y/zI0h1Lee/n97j34nsZ33c8lStU5qGvH+Kl5S9R/ZnqvHblawzrMOy022flZrEmZQ0xNWPYuH8jV310FclHk/lj8z/y2pWvUT+iPpd/eDmtXm3FnR3uJK5hHIt3LGbxb4vZcWgH4aHhZOZm0mdyHzbu30hExQie6/sc93W+r+x+CcarxB3I4zfi4uI0Pj7e12EYU+Zy83Lp/G5nUo6m8OvoX6lasSoAczfN5cqPrgQgqlIU60avO+Ge/DsP7WT62un8d9t/WfzbYo5mHyWyYiQhEkKNSjX4+E8fnzAT18b9G3nlx1d4fcXrKEq9qvXo2bQnvZv1ZliHYYxZOIbXV7zOqLhRPNH7CWpXqV22vwhTbCKSoKpxhS6zImCMf3hv5Xv8efafmXrd1BMmYT+adZSWE1oyuPVgJv0yifNrn8+iYYuoFl6NpTuWcvXUq0nLSOP82udzWfPL6BrdlSW/LWH/8f2Mu3Tcacfyb9i3AREhpmbMCfP15ublkpaRZh/+fsSKgDF+LiMng5gJMTSKbMQPd/1wyiTqqoqIMHfTXAZOG0i3xt147crX6DmxJ7Uq12LWzbM4v/b5Pore+NqZioCdEzDGh3LycgqGdx7KOMTw2cOpXaU2vyT/wiXRl/B4r8epFl6NF5a9wK7Du5g4aOIpBQAoaOsf059Jgydx62e30u7NdlQPr87cW+dyXs3zyjQv4z+sCBhTxtanrueTdZ8wfe10NuzfQNforiQdTuK3Q7+Rp3mAc5vlZTuX8fwPz1O7Sm0OZhzk+guu57IWl511/7fE3kJ6ZjrvrHyHiYMnWgEwZ2TdQcaUgqzcLLJzswtO3v528Dcm/zKZ6eumsyZlDYLQo2kP2tRuQ+LeRJpHNSemZgxXxlzJt9u+JbZeLJXDKpOwJ4EtB7ZwKPMQE/pPoE7VOj7OzPgj6w4ypowk7k3kg58/YMrqKRzLPsboi0czsPVArpt+HfuO7aN7k+5M6D+B69pcR4PIBoXuo2t014LnRfnmb8y5sCJgjJcs+W0JPSf2pGJoRQafP5is3CxeXP4iz//wPADf3/E93Zp083GUxpzIioAxXrIlbQsAK0espG1d547pe4/s5Y+T/khsvVgrAKZcsiJgjJekHU8DoFG13+dHqh9RnzX3rMHfzr2Z4GFFwBgvSctIQxCqhVc7oT1EQuDUUZ3GlAt2A7kgpar27dTLDhw/QFTlKOdD3xg/YX+tQWrUV6NoOaElCbsTfB1KwEjLSCOqks2la/yLFYEgoqrM3zKfIZ8N4a2Et0g6nMSNM260IwIvSTueZhOqG79j5wQCWEZOBst3LSd+dzz1I+rzZvybLN25lKhKUdzQ9gYubXYpo74aRcKeBOIaFnodiSmGA8cPULNyTV+HYUyxlKgIiMj7OJPKp6jqhW5bTeBjoBmwHbhBVdPcOYRfBq4EjgHDVHWlu83twGPubp9S1UklT8V4OphxkI5vdWT7we0FbY0iG/H6la9zZ8c7CQ8L58DxA9w39z6mrp5qRcAL0jLSaFajma/DMKZYSnokMBF4FZjs0TYG+K+qPiMiY9zXfwP640wwHwN0Ad4AurhF4wkgDlAgQURmqWpaCWMqMxv2beDHpB9ZnbyarNwsBrQawMKtC/lD4z/4ZHYlVSUtI63gW+jG/Rv5+7d/Z8ehHUy5dgq9m/Vmy4EtXNzoYiqFVSrYrmblmvzpgj/xyk+vcE2ba+jepHuZx+4P0jPTWblnJQeOH+CaNtecdr0Dxw/YOQHjd0pUBFR1sYg0O6l5EM4E9ACTgEU4RWAQMFmdjuflIlJDRBq46y7In3heRBYA/YCpJYnJ21SVI1lHyMzNJDMnk6zcLOpH1OerTV9x/SfXAxAeGk6u5vLKT68AEFExggMPH6BCaIWz7v/N+DdZsHUBOw/tpEFkA25vfzsDWg2gYmjFYsV5LPsYj/z3EV5b8Rq3xN7CiqQVrN+3HoCx3cdyS+wtADSMbFjo9m9c9QYJuxO4bvp1xA+Pp1aVWgBUqVClWHGUhQ37NpB6LLXUi9WhjEM88/0zfLv9WzYf2Mz+4/sLlk0aPImh7Yeeso2qknY8zbqDjN/x5jmBeqq6x32+F8ifqboRsNNjvV1u2+naTyEiI4ARAE2aNPFiyIWbu2kuI78cyc7DO09oD5VQcjWXrtFdeX/g+8TUimHR9kV8/uvndKjfgeGzh/Nj0o+Ffkgt27mM2RtmM3fzXPYe2Uvy0WSiq0XTrEYzViStYNaGWdSqXIsZN8wg9Wgq17S5puAWw4U5mHGQB+c9yKRfnB60FlEt+HTdp3SJ7sKouFEMPn8wjas3PmuuNSrV4IubvqDLu13o858+7Dy0k+y8bJ7v+zy9m/UmLSONtONppGWkEVs3losbXVzM36Z35OTl0HNiT1KOpvB4z8d5tMejhIeFn/N+kw4nMXvjbA5nHuZw5mEaRTbi2aXPsvPwTro36c6fLvgTLaJa0KpWK17+8WVGfjmS9vXa075++xP2cyTrCLmaayeGjd8plRPDqqoi4rUhJ6r6NvA2OHcR9dZ+C5N8JJmhnw+lTpU6PHPZM1SpUIXwsHAqhFRg04FNRFaMZHin4QWzKvVp0Yc+LfpwMOMgI78cyfwt8+nepDuqyox1M7iw7oVs3L+RwR8PJiwkjG6Nu3F+7fOpUakGr175KmEhYeTk5bBgywLumnUXl//ncrLzshnfZzx/7fbXQmNcsGUBd866kz3pe7i7091Ehkfyz0v/SXhoeKH3mj+bNnXaMOXaKQyaNoi4hnHUrFyTB79+8JT1QiWUD6/9sGBWq6U7lvLi8hepFFaJ0ReP5pLGlxTr524+sJnlu5ZzWfPLTriZmqry896faV+vPaEhoRzPPs5Ti58i5WgKNSrVYNzicUz6ZRJjuo3hjo53nNDFVRzb0rbRc2JPdh3eBYAgBdMpLr1z6Qk3cgPnxm4XvXURvSb24v4u9zO2+1gqV6gMOF1BgHUHGb/jzSKQLCINVHWP292T4rYnAZ5fSaPdtiR+7z7Kb1/kxXiKZd+xfXzx6xdM+GkCR7KOsOj2RQX3fymKGpVq0K1xN55f9jyZOZm0q9eOITOHFCxvXK0xq0etpnql6qdsGxYSRv+Y/jza41HunXsvkRUjefK7J+nWpNsJH6xzNs0h+Ugyw2cPp1WtVnx212de+2Z+deurWT1qNc2jmhMqoczaMIsQCSGqchRRlaKoWrEqQz4bwsMLHqZ7k+6MWTiGKaunULdqXXLzcpm2Zho//vnHIp9gPp59nAEfDWDD/g2ESAh9W/Tl9va3M/j8wbz383vcN/c+Hur6EHWr1uXF5S+ScjSFQa0HMfPGmSzcupAnFj3BPXPu4aklT/Hnjn8m+Wgyj/V8jOhq0UX6+arKiC9HkJ6ZzvK7lhNbL5ZKYZVY/NtiYmrGnHDrh3z1I+rz36H/5fFvH2fc4nFMWzONx3s+ztNLnuZgxkEA6w4yfqfE8wm45wS+9Bgd9Byw3+PEcE1VfVhErgLuxRkd1AV4RVU7uyeGE4CL3F2uBDrlnyM4nZLMJ3Aw4yAz18+kYWRDmlRvwr++/xf1qtbjyd5PsiJpBRN/mcjHaz4mMzeTyIqRfHL9J1zR8opi/QyAHYd28Og3jzJl1RQUpXp4dRpVa8S61HU8fMnDPNv32TNun5OXw5cbvyS2biz9p/Rn+8HtjL54NI/1fIzpa6dzz5x7AGgQ0YB1o9dRo1KNYsd4LqasmlJQ2MJDw/nrJX9lTPcxZOdl0+LlFnRu1Jn/XPMf6lStQ3ZuNn3+04eGkQ2ZNHjSKec6xiwcw7NLn+Xdq99l+8HtTF41mR2HdlClQhWOZR8r+Bfg8vMu59Eej9Kzac+C7VWVb7d/y7jF41i0fREArWq14rth350wyTpAnuYxa8Ms0jPTqVu1LvUj6pOwJ4G7Zt3Fy/1e5v4u9xf7d7Fw60JGfjmSrWlbqVm5JvWq1iMzN5MFty2gRVSLYu/PmNLk9TmGRWQqzrf42kAyziifz4HpQBPgN5whogfcIaKv4pz0PQbcoarx7n7uBB5xd/u0qn5wtp99chHIzcslNCT0lPWSjyQzfe10Lml8Cc8ufZZP1n1yyjrR1aLZdXgXkRUjGdp+KMMvGs4FdS4o0ondM1mbspaXf3yZW2NvpWmNpjw470Em9J9QpD76fPuO7WPswrG8n/g+VStUJT0rnatbXU3rWq0Z2HogPZr2OKcYS+JI1hEi/y8SgLX3rOWCOhcULBu/dDx/W/g3AJpUb0L9iPr8lPQTAJc0voRJgyfRsmZLAL7f8T29Jvbijg538O7AdwHng3rR9kXMWDeDRpGNGNJuCG8nvM3g8wef9Wgn6XASW9O20m9KP5pWb8qkwZMKtkncm8jIL0cWxOKpd7PezB8yv8Tv97HsY7wV/xZ9WvQhtl5sifZhTFkIyInms3KzGD57OB+t/ohLGl/Ci5e/SKeGnTiceZjnlz3Piz+8yNHsowXbje0+lv4t+7M1bSsAw74YRoiEMHnwZAa2HkhkeKSvUjqjNSlreOybx6hSoQofDPrAKydDz8XcTXOpW7UunRp2OqFdVflh1w8s27mMhD0JrNyzkl5Ne9GraS/um3sfitK+XnsycjJYlbyKhpENiR8R79WjmUXbF3HTjJtIOZrCHR3uYHin4fSf0p/w0HCe6/scXaK7sO/YPnYe2knK0RTuuuiucjkKyhhvC7gi8M3Sb7hu+nUs3LqQ29rdxrzN80g9lkrnRp3ZmraVfcf2cUPbG/jrJX9lVfIqDhw/wP1d7j+hS+KBuQ9QP6I+Y3uM9WE2wWFr2lb+8vVfOJRxiPCwcOpH1OfZPs+e0m3jDYczDzPuu3H8+8d/k5OXQ0TFCBJHJto8uyaoBVQRaNexnYbdHcaq5FW8O/BdhnUYRtrxNCYmTmTyqsnUj6jPuEvH2RWwQW7T/k0s2LqA9vXa22QuJugFVBEIiw7TyqMrM/1P0+kf09/X4RhjTLkXUBPNh4aE2uG9McZ4id/dSrpVrVZWAIwxxkv8rgiEh/p2dIwxxgQSvysCxhhjvMeKgDHGBDErAsYYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPErAgYY0wQsyJgjDFBzIqAMcYEMSsCxhgTxLxWBESktYgkejwOi8iDIvKkiCR5tF/psc1YEdksIhtEpPiT+hpjjDknXruVtKpuADoAiEgokATMBO4AXlLV5z3XF5ELgJuAtkBDYKGItFLVXG/FZIwx5sxKqzvoMmCLqv52hnUGAdNUNVNVtwGbgc6lFI8xxphClFYRuAmY6vH6XhFZJSLvi0iU29YI2Omxzi63zRhjTKuMbB8AABF6SURBVBnxehEQkYrAQOATt+kN4DycrqI9wAsl2OcIEYkXkfjU1FSvxWqMMcGuNI4E+gMrVTUZQFWTVTVXVfOAd/i9yycJaOyxXbTbdgpVfVtV41Q1rk6dOqUQsjHGBKfSKAI349EVJCINPJZdA6xxn88CbhKRcBFpDsQAP5VCPMYYY07DqxPNi0hVoC8w0qN5vIh0ABTYnr9MVdeKyHRgHZADjLaRQcYYU7a8WgRU9ShQ66S2286w/tPA096MwRhjTNHZFcPGGBPErAgYY0wQsyJgjDFBzIqAMcYEMSsCxhgTxKwIGGNMELMiYIwxQcyKgDHGBDErAsYYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPErAgYY0wQsyJgjDFBzIqAMcYEMSsCxhgTxKwIGGNMEPN6ERCR7SKyWkQSRSTebaspIgtEZJP7b5TbLiLyiohsFpFVInKRt+MxxhhzeqV1JHCpqnZQ1Tj39Rjgv6oaA/zXfQ3QH4hxHyOAN0opHmOMMYUoq+6gQcAk9/kkYLBH+2R1LAdqiEiDMorJGGOCXmkUAQXmi0iCiIxw2+qp6h73+V6gnvu8EbDTY9tdbtsJRGSEiMSLSHxqamophGyMMcEprBT22V1Vk0SkLrBARH71XKiqKiJanB2q6tvA2wBxcXHF2tYYY8zpef1IQFWT3H9TgJlAZyA5v5vH/TfFXT0JaOyxebTbZowxpgx4tQiISFURicx/DlwOrAFmAbe7q90OfOE+nwUMdUcJdQUOeXQbGWOMKWXe7g6qB8wUkfx9f6Sq80RkBTBdRO4CfgNucNefA1wJbAaOAXd4OR5jjDFn4NUioKpbgfaFtO8HLiukXYHR3ozBGGNM0dkVw8YYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPErAgYY0wQsyJgjDFBzIqAMcYEMSsCxhgTxKwIGGNMELMiYIwxQcyKgDHGBDErAsYYE8SsCBhjTBCzImCMMUHMioAxxgQxKwLGGBPEvFYERKSxiHwrIutEZK2IPOC2PykiSSKS6D6u9NhmrIhsFpENInKFt2IxxhhTNN6cXjIH+B9VXelONp8gIgvcZS+p6vOeK4vIBcBNQFugIbBQRFqpaq4XYzLGGHMGXjsSUNU9qrrSfZ4OrAcanWGTQcA0Vc1U1W04k8139lY8xhhjzq5UzgmISDOgI/Cj23SviKwSkfdFJMptawTs9NhsF6cpGiIyQkTiRSQ+NTW1NEI2xpig5PUiICIRwKfAg6p6GHgDOA/oAOwBXijuPlX1bVWNU9W4OnXqeDVeY4wJZl4tAiJSAacATFHVzwBUNVlVc1U1D3iH37t8koDGHptHu23GGGPKiDdHBwnwHrBeVV/0aG/gsdo1wBr3+SzgJhEJF5HmQAzwk7fiMcYYc3beHB3UDbgNWC0iiW7bI8DNItIBUGA7MBJAVdeKyHRgHc7IotE2MsgYY8qW14qAqn4PSCGL5pxhm6eBp70VgzHGmOKxK4aNMSaIWREwxpggZkXAGGOCmBUBY4wJYlYEjDEmiFkRMMaYIGZFwBhjgpgVAWOMCWJWBIwxJohZETDGmCBmRcAYY4KYFQFjjAliVgSMMSaIWREwxpggZkXAGGOCmBUBY4wJYlYEjDEmiPm8CIhIPxHZICKbRWSMr+Mxxphg4tMiICKhwGtAf+ACnPmIL/BlTMYYE0x8fSTQGdisqltVNQuYBgzycUzGGBM0fF0EGgE7PV7vctuMMcaUAV8XgSIRkREiEi8i8ampqb4OxxhjAoavi0AS0NjjdbTbdgJVfVtV41Q1rk6dOmUWnDHGBDpfF4EVQIyINBeRisBNwCwfx2SMMUEjzJc/XFVzRORe4GsgFHhfVdf6MiZjjAkmPi0CAKo6B5jj6ziMMSYY+bo7yBhjjA9ZETDGmCBmRcAYY4KYqKqvYygWEUkFfvNoqg3s81E4ZSHQ84PAz9Hy80+BlFdTVS10fL3fFYGTiUi8qsb5Oo7SEuj5QeDnaPn5p0DN62TWHWSMMUHMioAxxgSxQCgCb/s6gFIW6PlB4Odo+fmnQM3rBH5/TsAYY0zJBcKRgDHGmBKyImCMMUHMioApEyIivo7BmJPZ36WfFAERaS0ifhFrSYjILSLS3n0eqH+UAfv+BYtA/j8YzMr1myoifUXkR+DPlPNYS0JE+ojIEuDfQEcADbAz9SJylYh8CYwTkW6+jsfbRGSwiEwQkZq+jqU0iMhAEXnI13F4m4j0E5EvcP4uA/6CsDPx+a2kT+Z+Ew4DHgduBv6mqp95LvfnD0o3v0rAJKAu8BQwCKjiLg9V1VzfReg9ItIJeAJ4EqgG3C4iMao6UURCVDXPpwGeA/d9vAZ4GogEFonITH/OyZOIhAH/A4wCmojIN6qa6M9/n+57Fg68CbQExgN/BO4Ske2qGii3iCiWcvftWh3ZQB4wI78AiEgPEang2+jOnZvfcWCKqvZW1a+BZcBt7nK//A92Gn2AJe6cEV8Ae4H7RaS6qub5c9eX+0VkK9AdeAAYgjM9akBQ1RxgA3A+8BDwltvut3+f7v+9DJy/xV6qOgv4DGeofFAWAChHRUBE7heRd0RkhNv0JtBARD4QkdXAw8B7wJ3u+n71AeKR33AAVf3CbQ8FtgFrRaTxmfZR3p2cI/AtcLWIRLmFLxs4BPwN/K/rS0RuF5G+Hk1rVHW/qn6Kk9u17jSpfsl9/54RkRvcpq9UNUNV/w3UFZFb3PX86svYyXmp6kxVzXVffwqcLyLjRKS7byP1jXJRBERkGHALzhtyq4g8BmQCnwMVgeuBge7ya0WkiT99gJyU3xAReUREWkDBN6vDQHvgoM+CPEeF5PgosB1n6tD/uOc+WgDPADVEpKqPQi02EYkSkRk4sb/gFm4Az6OZl4GrgQtP2rbcf1kRx1+AG4F44B/u+xnlsdpDwHMA7pF6uXe6vESknrtKCk53UB9gNzBMRAq902YgKxdFALgMeFZV5+H0Q4YDI1X1c2CEqv7qfuivwvmg9Is/Qg8n51cRp/sAAFVdDWQAN/kmPK84OcdKwFBVvQ+4B/inqt6Bk2dlVT3qu1CLR1XTgPlAGyAB+LvHMnX/XQokAv1F5Pz8I1p/+LLixngp8JiqzgD+ArQDrvBYZyawUUT+F5xBDb6ItThOk1d7oJ+7fJGqrna7vlbjnJc77qt4fcWnRcBjyNnPwAAAVY0HlgLNRaTbSR8WtwOVgbQyDbSEzpDfcqBR/uGn+23xa6CSP3xz9HSW97CViPRQ1R2qusBd7ypgS9lHWjIe78dkVT0IvI5zNNrUPa8R6vE7+DcwFvgO56R/uTsSODkej9jjgR4AbiHfBLQVkdYeq48CxovIXqBRGYRbZMXIayPQRkRanbSLy3EKgBWB0iQi3UTkvPzXHiMplgIhItLTfb0G2AM0dLe7TkR+welOGOWe3Cl3ipnfbqCBu57ifGgcLe/fHEuQY313u54i8h0Qg3O+p1wqJL/8b/oZ7r8rgLk4o4JQ1Vy3GNQDXgW+ATqo6lOe25cjlT1feLx/m4FIEYl1X38HVMcZ+YSIdADewenuu0hVJ5VNuEVW3LyqiUhFEblNRFYBzYCx/nziu6TKpAiIyEUiMh/nP0h1j/b8n78JWAvcKM4QtF1APaC5u3wjcLeqDlXV5LKIuThKmF99nD+8fP+rqu+XUcjF5oX3cDtwj6peUx5HYpwhP5FTL5J6FWgpIm1FpI6INMeZgeo+VR2oqnvKLvKiEZGuIvIp8JqIXJ5/XkOcoaAAPwE5wOUiEqaq63C+7eePod+P8/5dr6q7yzr+0zmHvDqpahawE+eL5VBVTfFFDr5WqkVARCqIyFs4t2R9BafLo7e7LNSjWqcDS3DOBTwvzuiDKNyp3dx+ux9KM9aS8EJ++/P35f5BljtefA93qOraMg7/rIqQn7rf9CuLSAQ4uQAzcfqRlwBR7hHBDp8kcRYi0hunG+sznGGfQ4Aoca7VyAFQ1c04XSfnAWPcTTNxp3JV1Z3uuatyw0t5LXLP5wSt0j4SCAcWAz1U9UucN6uNW5FzAUTkH8BHOEMHH8f54Fjivi5vh5wnC/T8IPBzLEp+TwBTcLojEZGbcU52Pw/EqupKn0RedO2AFao6BfgQqAAcyS/gIvKUiLyHc9L7FaCziCQAB3CKYnl1LnnN91HM5Y7XrxgWka7AAVXdiNPHPcVjcSiQq6o57omcWJw+4jGqusXd/k6gqqqmezs2bwj0/CDwcyxBfq2Bv+bnh3NdR29V3VamgRfRSfmBU+SeFJHdOMVrPfC6iHyN0x3SAvi7qm53t78FCHNPhJcbgZqXz6mqVx5ADeArnG6Bx3A+BAAECHGftwSScQ6fwZ3Uxn0e4q1YSuMR6PkFQ45eyC/U1zkUM78Ij2WdgfeB69zXd+Gc6G1f3t+/QM2rvDy82R1UFefQ8T73eU8ouFQ7zz25tt1dp1f+MnBOLmr5v+dKoOcHgZ/jueZX3keOnJxfj/wFqvoTUAe3LxznBHgN3OHW5fz9C9S8yoVzKgIiMlREeolINVVNwjm5Nh3ngqAuIpI/xFPcNyLc3TQjvx1OGM5VrgR6fhD4OVp+BfmF49yj6h5308uAmu565S6/QM2rPCp2ERBHAxH5FufirVuBN0Sktjr3GTkGLMQ5OfhHcL5NuSMtjro/s2t+u7cS8ZZAzw8CP0fL74T8LgNQ1UxgFhAhIotx7tB7r5ajYZGBmle5V5y+I9w+UaAV8GF+GzAB+Oykdf+Cc5vk6kAVj/aKpdW3da6PQM8vGHK0/ArNrwbOrTrAuaiqha/zCJa8/OFRpCMBcS6N/xfwLxHphTNaIhcKboD2AHCJuyzfO0AEsADYln/4puVwPHyg5weBn6Pld9b8totII1U9rqpbyzj80wrUvPzJWYuA+8tPwDkE2wyMw7mB26Ui0hkK+t2edB/5rsLpp/sFZyx1ubnK0FOg5weBn6Pld9b8EnHySyq7qM8uUPPyN0W5TiAPeEFV/wMgIh1xbgXwd+ANoJM4oyo+B/4oIs3UGZebAfRR1cWlErn3BHp+EPg5Wn7+mV+g5uVXitIdlABMl9/vob4UaKKqE4FQEbnPrdbROBfZbAdn0hQ/eZMCPT8I/BwtP//ML1Dz8itnLQKqekxVM/X3MdJ9gVT3+R04l9h/CUwFVkL5u33umQR6fhD4OVp+/plfoOblb4p82wi3WivOnSFnuc3pwCM4sylty++bU9VyN6zubAI9Pwj8HC0//8wvUPPyF8W5TiAP5wZN+4B2boV+HMhT1e8D4ORMoOcHgZ+j5eefAjUvvyDFKazi3MBpmfv4QFXfK63AfCHQ84PAz9Hy80+Bmpc/KG4RiAZuA15U50q9gBLo+UHg52j5+adAzcsfFKsIGGOMCSw+nWjeGGOMb1kRMMaYIGZFwBhjgpgVAWOMCWJWBIwxJohZETDmDEQkV0QSRWStiPwiIv/j3tTsTNs0E2dSc2PKPSsCxpzZcVXtoKptce5t0x944izbNAOsCBi/YNcJGHMGInJEVSM8XrcAVgC1gabAf3AmPwdnWsNlIrIcaANsAyYBrwDPAL1x5jB+TVXfKrMkjDkDKwLGnMHJRcBtO4gzA1Y6zv1tMkQkBpiqqnEi0hv4X1Ud4K4/Aqirqk+JMzH6UuB6Vd1WpskYU4gi30XUGHOKCsCrItIBZ0rEVqdZ73KcG6P9yX1dHYjBOVIwxqesCBhTDG53UC6QgnNuIBloj3N+LeN0mwH3qerXZRKkMcVgJ4aNKSIRqQO8Cbzq3te+OrDHnf3qNiB/hqx0INJj06+BUSJSwd1PKxGpijHlgB0JGHNmlUUkEafrJwfnRPCL7rLXgU9FZCgwDzjqtq8CckXkF2Ai8DLOiKGV7sxYqcDgskrAmDOxE8PGGBPErDvIGGOCmBUBY4wJYlYEjDEmiFkRMMaYIGZFwBhjgpgVAWOMCWJWBIwxJoj9P0+gnmsfxk+6AAAAAElFTkSuQmCC\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ]
     }
-   ],
-   "source": [
-    "dates = pd.date_range(start=\"2018-03-28\", end=\"2018-04-26\")\n",
-    "plt.plot(dates, forecast_predicted, color='y')\n",
-    "df['Adj. Close'].plot(color='g')\n",
-    "plt.xlim(xmin=datetime.date(2017,4,26))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  ]
 }


### PR DESCRIPTION
As I went through the 'Predicting Stock Prices' project on TheCodexMe, I found the `df['Prediction'] = df[['Adj. Close']].shift(-forecase)` line confusing. 

I tried removing it and replacing it with `df['Prediction'] = df[['Adj. Close']]` and then indexed the np array formed from it using `y = y[forecast : ]`. 

With these two lines of code changed, I was still able to get the graph at the end because we are not really using the NaN values. Instead, we're using all values from `df['Adj. Close']` except for the first 30.
